### PR TITLE
fix(auth): set AuthStyleInParams for OAuth2

### DIFF
--- a/pkg/auth/oauth.go
+++ b/pkg/auth/oauth.go
@@ -91,8 +91,9 @@ func NewOAuthConfig() (*OAuthConfig, error) {
 		RedirectURL: redirectURI,
 		Scopes:      strings.Split(DefaultScope, " "),
 		Endpoint: oauth2.Endpoint{
-			AuthURL:  AuthURL,
-			TokenURL: TokenURL,
+			AuthURL:   AuthURL,
+			TokenURL:  TokenURL,
+			AuthStyle: oauth2.AuthStyleInParams,
 		},
 	}
 


### PR DESCRIPTION
<!-- mesa-description-start -->
## TL;DR

Fixes the OAuth2 authentication flow by sending client credentials in the request body, as required by the provider.

## Why we made these changes

The upstream OAuth2 provider expects the `client_id` and `client_secret` to be in the request parameters during the token exchange. The previous configuration sent them in the `Authorization` header, causing authentication to fail.

## What changed?

- Set `AuthStyle: oauth2.AuthStyleInParams` in the `oauth2.Config`. This forces the credentials into the request body, allowing the token exchange to succeed.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/onkernel/settings/pull-requests)_</sup>
<!-- mesa-description-end -->