### PR TITLE
Update from `docs.` to `/docs`

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,7 +43,7 @@ npms:
     repository: "https://github.com/onkernel"
     bugs: https://github.com/onkernel/cli/issues
     description: Kernel CLI
-    homepage: https://docs.onkernel.com
+    homepage: https://onkernel.com/docs
     license: MIT
     author: "Rafael Garcia <raf@onkernel.com>"
     access: public
@@ -89,7 +89,7 @@ release:
 
     ## What to do next?
 
-    - Read the [documentation](https://docs.onkernel.com)
+    - Read the [documentation](https://onkernel.com/docs)
     - Join our [Discord server](https://discord.gg/FBrveQRcud)
     - Follow us on Twitter [here](https://twitter.com/rfgarcia) and [here](https://x.com/juecd__)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 The Kernel CLI is a fast, friendly command‑line interface for Kernel — the platform that provides sandboxed, ready‑to‑use Chrome browsers for browser automations and web agents.
 
-Sign up at [onkernel.com](https://www.onkernel.com/) and read the [docs](https://docs.onkernel.com/introduction).
+Sign up at [onkernel.com](https://www.onkernel.com/) and read the [docs](https://onkernel.com/docs/introduction).
 
 ## What's Kernel?
 
@@ -318,15 +318,15 @@ kernel browsers fs list-files my-browser --path "/tmp"
 
 For complete documentation, visit:
 
-- [📖 Documentation](https://docs.onkernel.com)
-- [🚀 Quickstart Guide](https://docs.onkernel.com/quickstart)
-- [📋 CLI Reference](https://docs.onkernel.com/reference/cli)
+- [📖 Documentation](https://onkernel.com/docs)
+- [🚀 Quickstart Guide](https://onkernel.com/docs/quickstart)
+- [📋 CLI Reference](https://onkernel.com/docs/reference/cli)
 
 ## Support
 
 - [Discord Community](https://discord.gg/kernel)
 - [GitHub Issues](https://github.com/onkernel/kernel/issues)
-- [Documentation](https://docs.onkernel.com)
+- [Documentation](https://onkernel.com/docs)
 
 ---
 


### PR DESCRIPTION
<!-- mesa-description-start -->
## TL;DR

Updated documentation links to use the `/docs` path instead of the `docs.` subdomain.

## Why we made these changes

To consolidate our web properties onto a single domain, simplifying our URL structure and infrastructure.

## What changed?

- Replaced all hardcoded instances of `docs.SUBDOMAIN.com` with the new `/docs/...` path across the codebase.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/onkernel/settings/pull-requests)_</sup>
<!-- mesa-description-end -->