### PR TITLE
Add version column and filtering to invocation history command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/charmbracelet/fang v0.2.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/joho/godotenv v1.5.1
-	github.com/onkernel/kernel-go-sdk v0.11.4
+	github.com/onkernel/kernel-go-sdk v0.11.5
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pterm/pterm v0.12.80
 	github.com/samber/lo v1.51.0

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/muesli/mango-pflag v0.1.0 h1:UADqbYgpUyRoBja3g6LUL+3LErjpsOwaC9ywvBWe
 github.com/muesli/mango-pflag v0.1.0/go.mod h1:YEQomTxaCUp8PrbhFh10UfbhbQrM/xJ4i2PB8VTLLW0=
 github.com/muesli/roff v0.1.0 h1:YD0lalCotmYuF5HhZliKWlIx7IEhiXeSfq7hNjFqGF8=
 github.com/muesli/roff v0.1.0/go.mod h1:pjAHQM9hdUUwm/krAfrLGgJkXJ+YuhtsfZ42kieB2Ig=
-github.com/onkernel/kernel-go-sdk v0.11.4 h1:vgDcPtldfEcRh+a1wlOSOY2bBWjxLFUwHqeXHHQ4OjM=
-github.com/onkernel/kernel-go-sdk v0.11.4/go.mod h1:MjUR92i8UPqjrmneyVykae6GuB3GGSmnQtnjf1v74Dc=
+github.com/onkernel/kernel-go-sdk v0.11.5 h1:LApX5A/Ful62LwNTW+srhi/3cx3W04pzgZ361PlDEAc=
+github.com/onkernel/kernel-go-sdk v0.11.5/go.mod h1:MjUR92i8UPqjrmneyVykae6GuB3GGSmnQtnjf1v74Dc=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## PR Description:

### Summary
This PR enhances the `kernel invoke history` command by adding support for displaying and filtering invocations by version.

### Changes
- Added a "Version" column to the invocation history table output
- Added `--version` flag to filter invocations by version
- Updated kernel-go-sdk dependency from v0.11.4 to v0.11.5

### New Features
1. **Version Column**: The invocation history table now displays the version of each invocation between the "Action" and "Status" columns
2. **Version Filtering**: Users can now filter invocations by version using the `--version` flag

### Usage Examples
```bash
# Show all invocations with version column
kernel invoke history

# Filter by version only
kernel invoke history --version v1.2.3

# Filter by app name only  
kernel invoke history --app myapp

# Filter by both app name and version
kernel invoke history --app myapp --version v1.2.3
```

### Implementation Details
- Leverages the existing `Version` field from the SDK's `InvocationListResponse` struct
- Uses the SDK's `Version` filter parameter in `InvocationListParams`
- Maintains backward compatibility with existing usage patterns
- Updates debug messages to reflect active filters

### Dependencies
- Updated `github.com/onkernel/kernel-go-sdk` from v0.11.4 to v0.11.5


<img width="978" height="120" alt="image" src="https://github.com/user-attachments/assets/4e1aada8-e039-4aff-b535-d61f658ed235" />
