### PR TITLE
Truncate long columns instead of line wrapping

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -80,9 +80,6 @@ func runAppList(cmd *cobra.Command, args []string) error {
 		envVarsStr := "-"
 		if len(app.EnvVars) > 0 {
 			envVarsStr = strings.Join(lo.Keys(app.EnvVars), ", ")
-			if len(envVarsStr) > 50 {
-				envVarsStr = envVarsStr[:47] + "..."
-			}
 		}
 
 		actionsStr := "-"
@@ -90,9 +87,6 @@ func runAppList(cmd *cobra.Command, args []string) error {
 			actionsStr = strings.Join(lo.Map(app.Actions, func(a kernel.AppAction, _ int) string {
 				return a.Name
 			}), ", ")
-			if len(actionsStr) > 50 {
-				actionsStr = actionsStr[:47] + "..."
-			}
 		}
 
 		tableData = append(tableData, []string{

--- a/cmd/proxies/get.go
+++ b/cmd/proxies/get.go
@@ -38,6 +38,21 @@ func (p ProxyCmd) Get(ctx context.Context, in ProxyGetInput) error {
 	// Display type-specific config details
 	rows = append(rows, getProxyConfigRows(item)...)
 
+	// Display status with color
+	status := string(item.Status)
+	if status == "" {
+		status = "-"
+	} else if status == "available" {
+		status = pterm.Green(status)
+	} else if status == "unavailable" {
+		status = pterm.Red(status)
+	}
+	rows = append(rows, []string{"Status", status})
+
+	// Display last checked timestamp
+	lastChecked := util.FormatLocal(item.LastChecked)
+	rows = append(rows, []string{"Last Checked", lastChecked})
+
 	PrintTableNoPad(rows, true)
 	return nil
 }

--- a/cmd/proxies/helpers.go
+++ b/cmd/proxies/helpers.go
@@ -1,14 +1,193 @@
 package proxies
 
 import (
+	"unicode/utf8"
+
 	"github.com/pterm/pterm"
 )
 
-// PrintTableNoPad prints a table without padding
+// PrintTableNoPad prints a table with intelligent column truncation to prevent wrapping.
+// It detects terminal width and truncates cells that would cause line wrapping,
+// adding "..." to indicate truncation.
 func PrintTableNoPad(data pterm.TableData, withRowSeparators bool) {
-	table := pterm.DefaultTable.WithHasHeader().WithData(data)
+	if len(data) == 0 {
+		return
+	}
+
+	// Get terminal width
+	termWidth := pterm.GetTerminalWidth()
+	if termWidth <= 0 {
+		termWidth = 80 // fallback
+	}
+
+	// Truncate data to fit terminal width
+	truncatedData := truncateTableData(data, termWidth)
+
+	table := pterm.DefaultTable.WithHasHeader().WithData(truncatedData)
 	if withRowSeparators {
 		table = table.WithRowSeparator("-")
 	}
 	_ = table.Render()
+}
+
+// truncateTableData intelligently truncates table cells to fit within terminal width
+func truncateTableData(data pterm.TableData, termWidth int) pterm.TableData {
+	if len(data) == 0 {
+		return data
+	}
+
+	numCols := len(data[0])
+	if numCols == 0 {
+		return data
+	}
+
+	// Calculate separator space: " | " between each column (3 chars per separator)
+	separatorSpace := (numCols - 1) * 3
+
+	// Define minimum column widths (these are the bare minimum before aggressive truncation)
+	minWidths := make([]int, numCols)
+	for i := 0; i < numCols; i++ {
+		minWidths[i] = 8 // minimum 8 chars per column
+	}
+
+	// Calculate natural widths (what each column would want)
+	naturalWidths := make([]int, numCols)
+	for colIdx := 0; colIdx < numCols; colIdx++ {
+		maxWidth := 0
+		for _, row := range data {
+			if colIdx < len(row) {
+				cellWidth := utf8.RuneCountInString(row[colIdx])
+				if cellWidth > maxWidth {
+					maxWidth = cellWidth
+				}
+			}
+		}
+		naturalWidths[colIdx] = maxWidth
+	}
+
+	// Calculate available space for content
+	availableWidth := termWidth - separatorSpace - 2 // -2 for margins
+
+	// Distribute width among columns
+	columnWidths := distributeColumnWidths(naturalWidths, minWidths, availableWidth)
+
+	// Truncate cells based on calculated widths
+	result := make(pterm.TableData, len(data))
+	for rowIdx, row := range data {
+		result[rowIdx] = make([]string, len(row))
+		for colIdx, cell := range row {
+			if colIdx < len(columnWidths) {
+				result[rowIdx][colIdx] = truncateCell(cell, columnWidths[colIdx])
+			} else {
+				result[rowIdx][colIdx] = cell
+			}
+		}
+	}
+
+	return result
+}
+
+// distributeColumnWidths calculates optimal width for each column
+// The first column (ID) is always given its full natural width and never truncated
+func distributeColumnWidths(naturalWidths, minWidths []int, availableWidth int) []int {
+	numCols := len(naturalWidths)
+	result := make([]int, numCols)
+
+	// Start with natural widths
+	copy(result, naturalWidths)
+
+	// Calculate total natural width needed
+	totalNatural := 0
+	for _, w := range naturalWidths {
+		totalNatural += w
+	}
+
+	// If natural widths fit, use them
+	if totalNatural <= availableWidth {
+		return result
+	}
+
+	// Priority: Always give the ID column (first column) its full natural width
+	if numCols > 0 {
+		result[0] = naturalWidths[0]
+		availableWidth -= naturalWidths[0]
+	}
+
+	// Now distribute remaining width among other columns (excluding ID)
+	if numCols <= 1 {
+		return result
+	}
+
+	// Calculate needs for non-ID columns
+	otherCols := numCols - 1
+	totalMinForOthers := 0
+	totalNaturalForOthers := 0
+	for i := 1; i < numCols; i++ {
+		totalMinForOthers += minWidths[i]
+		totalNaturalForOthers += naturalWidths[i]
+	}
+
+	if totalNaturalForOthers <= availableWidth {
+		// Other columns fit naturally
+		for i := 1; i < numCols; i++ {
+			result[i] = naturalWidths[i]
+		}
+		return result
+	}
+
+	if totalMinForOthers > availableWidth {
+		// Even minimums don't fit for other columns, distribute equally
+		for i := 1; i < numCols; i++ {
+			result[i] = availableWidth / otherCols
+			if result[i] < 5 {
+				result[i] = 5 // absolute minimum
+			}
+		}
+		return result
+	}
+
+	// Give other columns minimum, then distribute remainder proportionally
+	remainingWidth := availableWidth - totalMinForOthers
+	remainingNeed := totalNaturalForOthers - totalMinForOthers
+
+	for i := 1; i < numCols; i++ {
+		result[i] = minWidths[i]
+		if remainingNeed > 0 {
+			additionalNeed := naturalWidths[i] - minWidths[i]
+			additionalGrant := (additionalNeed * remainingWidth) / remainingNeed
+			result[i] += additionalGrant
+		}
+	}
+
+	return result
+}
+
+// truncateCell truncates a cell to maxWidth, adding "..." if truncated
+func truncateCell(cell string, maxWidth int) string {
+	cellWidth := utf8.RuneCountInString(cell)
+	if cellWidth <= maxWidth {
+		return cell
+	}
+
+	if maxWidth <= 3 {
+		// Too narrow for "...", just truncate
+		return truncateString(cell, maxWidth)
+	}
+
+	// Truncate and add "..."
+	return truncateString(cell, maxWidth-3) + "..."
+}
+
+// truncateString truncates a string to the specified number of runes
+func truncateString(s string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return ""
+	}
+
+	runes := []rune(s)
+	if len(runes) <= maxRunes {
+		return s
+	}
+
+	return string(runes[:maxRunes])
 }

--- a/cmd/proxies/helpers.go
+++ b/cmd/proxies/helpers.go
@@ -51,12 +51,15 @@ func truncateTableData(data pterm.TableData, termWidth int) pterm.TableData {
 	}
 
 	// Calculate natural widths (what each column would want)
+	// Strip color codes to measure visible characters only
 	naturalWidths := make([]int, numCols)
 	for colIdx := 0; colIdx < numCols; colIdx++ {
 		maxWidth := 0
 		for _, row := range data {
 			if colIdx < len(row) {
-				cellWidth := utf8.RuneCountInString(row[colIdx])
+				// Strip ANSI color codes to get visible character count
+				visibleText := pterm.RemoveColorFromString(row[colIdx])
+				cellWidth := utf8.RuneCountInString(visibleText)
 				if cellWidth > maxWidth {
 					maxWidth = cellWidth
 				}
@@ -87,8 +90,9 @@ func truncateTableData(data pterm.TableData, termWidth int) pterm.TableData {
 	return result
 }
 
-// distributeColumnWidths calculates optimal width for each column
-// The first column (ID) is always given its full natural width and never truncated
+// distributeColumnWidths calculates optimal width for each column using a two-pass strategy:
+// Pass 1: ID and short columns get their full natural width
+// Pass 2: Long columns share the remaining space
 func distributeColumnWidths(naturalWidths, minWidths []int, availableWidth int) []int {
 	numCols := len(naturalWidths)
 	result := make([]int, numCols)
@@ -107,55 +111,66 @@ func distributeColumnWidths(naturalWidths, minWidths []int, availableWidth int) 
 		return result
 	}
 
-	// Priority: Always give the ID column (first column) its full natural width
-	if numCols > 0 {
-		result[0] = naturalWidths[0]
-		availableWidth -= naturalWidths[0]
+	// Define threshold for "short" columns (these get priority)
+	const shortColumnThreshold = 15
+
+	// Pass 1: Give ID (index 0) and short columns their full natural width
+	remainingWidth := availableWidth
+	longColumnIndices := []int{}
+
+	for i := 0; i < numCols; i++ {
+		if i == 0 || naturalWidths[i] <= shortColumnThreshold {
+			// Short column or ID - give full natural width
+			result[i] = naturalWidths[i]
+			remainingWidth -= naturalWidths[i]
+		} else {
+			// Long column - defer to pass 2
+			longColumnIndices = append(longColumnIndices, i)
+		}
 	}
 
-	// Now distribute remaining width among other columns (excluding ID)
-	if numCols <= 1 {
+	// Pass 2: Distribute remaining space among long columns
+	if len(longColumnIndices) == 0 {
 		return result
 	}
 
-	// Calculate needs for non-ID columns
-	otherCols := numCols - 1
-	totalMinForOthers := 0
-	totalNaturalForOthers := 0
-	for i := 1; i < numCols; i++ {
-		totalMinForOthers += minWidths[i]
-		totalNaturalForOthers += naturalWidths[i]
+	// Calculate how much long columns want
+	totalLongNatural := 0
+	totalLongMin := 0
+	for _, idx := range longColumnIndices {
+		totalLongNatural += naturalWidths[idx]
+		totalLongMin += minWidths[idx]
 	}
 
-	if totalNaturalForOthers <= availableWidth {
-		// Other columns fit naturally
-		for i := 1; i < numCols; i++ {
-			result[i] = naturalWidths[i]
+	if totalLongNatural <= remainingWidth {
+		// Long columns fit naturally
+		for _, idx := range longColumnIndices {
+			result[idx] = naturalWidths[idx]
 		}
 		return result
 	}
 
-	if totalMinForOthers > availableWidth {
-		// Even minimums don't fit for other columns, distribute equally
-		for i := 1; i < numCols; i++ {
-			result[i] = availableWidth / otherCols
-			if result[i] < 5 {
-				result[i] = 5 // absolute minimum
+	if totalLongMin > remainingWidth {
+		// Even minimums don't fit, distribute equally
+		for _, idx := range longColumnIndices {
+			result[idx] = remainingWidth / len(longColumnIndices)
+			if result[idx] < 5 {
+				result[idx] = 5 // absolute minimum
 			}
 		}
 		return result
 	}
 
-	// Give other columns minimum, then distribute remainder proportionally
-	remainingWidth := availableWidth - totalMinForOthers
-	remainingNeed := totalNaturalForOthers - totalMinForOthers
+	// Give long columns minimum, then distribute remainder proportionally
+	extraSpace := remainingWidth - totalLongMin
+	extraNeed := totalLongNatural - totalLongMin
 
-	for i := 1; i < numCols; i++ {
-		result[i] = minWidths[i]
-		if remainingNeed > 0 {
-			additionalNeed := naturalWidths[i] - minWidths[i]
-			additionalGrant := (additionalNeed * remainingWidth) / remainingNeed
-			result[i] += additionalGrant
+	for _, idx := range longColumnIndices {
+		result[idx] = minWidths[idx]
+		if extraNeed > 0 {
+			additionalNeed := naturalWidths[idx] - minWidths[idx]
+			additionalGrant := (additionalNeed * extraSpace) / extraNeed
+			result[idx] += additionalGrant
 		}
 	}
 
@@ -163,19 +178,26 @@ func distributeColumnWidths(naturalWidths, minWidths []int, availableWidth int) 
 }
 
 // truncateCell truncates a cell to maxWidth, adding "..." if truncated
+// Handles ANSI color codes properly by measuring visible characters only
 func truncateCell(cell string, maxWidth int) string {
-	cellWidth := utf8.RuneCountInString(cell)
+	// Strip ANSI codes to measure visible width
+	visibleText := pterm.RemoveColorFromString(cell)
+	cellWidth := utf8.RuneCountInString(visibleText)
+
 	if cellWidth <= maxWidth {
 		return cell
 	}
 
+	// Cell needs truncation
+	// If the cell has color codes, we need to be careful about truncation
+	// For simplicity, strip colors, truncate, then return without color
 	if maxWidth <= 3 {
 		// Too narrow for "...", just truncate
-		return truncateString(cell, maxWidth)
+		return truncateString(visibleText, maxWidth)
 	}
 
 	// Truncate and add "..."
-	return truncateString(cell, maxWidth-3) + "..."
+	return truncateString(visibleText, maxWidth-3) + "..."
 }
 
 // truncateString truncates a string to the specified number of runes

--- a/cmd/proxies/list_test.go
+++ b/cmd/proxies/list_test.go
@@ -85,12 +85,11 @@ func TestProxyList_WithProxies(t *testing.T) {
 
 	assert.Contains(t, output, "mobile-1")
 	assert.Contains(t, output, "mobile")
-	assert.Contains(t, output, "Carrier: verizon")
 
 	assert.Contains(t, output, "isp-1")
 	assert.Contains(t, output, "-") // Empty name shows as "-"
 	assert.Contains(t, output, "isp")
-	assert.Contains(t, output, "Country: EU")
+	assert.Contains(t, output, "EU") // Country value
 }
 
 func TestProxyList_Error(t *testing.T) {

--- a/cmd/proxies/list_test.go
+++ b/cmd/proxies/list_test.go
@@ -64,24 +64,24 @@ func TestProxyList_WithProxies(t *testing.T) {
 	assert.NoError(t, err)
 	output := buf.String()
 
-	// Check table headers
+	// Check table headers (Config may be truncated in narrow terminals)
 	assert.Contains(t, output, "ID")
 	assert.Contains(t, output, "Name")
 	assert.Contains(t, output, "Type")
 	assert.Contains(t, output, "Protocol")
-	assert.Contains(t, output, "Config")
+	assert.Contains(t, output, "Status")
 
-	// Check proxy data
+	// Check proxy data - verify IDs and short columns are fully visible
 	assert.Contains(t, output, "dc-1")
 	assert.Contains(t, output, "https") // Protocol is shown
-	assert.Contains(t, output, "Country")
+	assert.Contains(t, output, "datacenter")
 
 	assert.Contains(t, output, "res-1")
+	assert.Contains(t, output, "residential")
 
 	assert.Contains(t, output, "custom-1")
 	assert.Contains(t, output, "My Proxy")
 	assert.Contains(t, output, "custom")
-	assert.Contains(t, output, "proxy") // Part of proxy.example.com, will be truncated
 
 	assert.Contains(t, output, "mobile-1")
 	assert.Contains(t, output, "mobile")
@@ -89,7 +89,6 @@ func TestProxyList_WithProxies(t *testing.T) {
 	assert.Contains(t, output, "isp-1")
 	assert.Contains(t, output, "-") // Empty name shows as "-"
 	assert.Contains(t, output, "isp")
-	assert.Contains(t, output, "EU") // Country value
 }
 
 func TestProxyList_Error(t *testing.T) {

--- a/cmd/table.go
+++ b/cmd/table.go
@@ -11,10 +11,18 @@ import (
 // adding trailing padding spaces after the last column and does not add blank
 // padded lines to match multi-line cells in other columns. The last column may
 // contain multi-line content which will be printed as-is on following lines.
+// It also intelligently truncates columns to prevent line wrapping.
 func printTableNoPad(data pterm.TableData, hasHeader bool) {
 	if len(data) == 0 {
 		return
 	}
+
+	// Get terminal width and truncate data to fit
+	termWidth := pterm.GetTerminalWidth()
+	if termWidth <= 0 {
+		termWidth = 80 // fallback
+	}
+	data = truncateTableData(data, termWidth)
 
 	// Determine number of columns from the first row
 	numCols := len(data[0])
@@ -110,4 +118,166 @@ func printTableNoPad(data pterm.TableData, hasHeader bool) {
 	}
 
 	pterm.Print(b.String())
+}
+
+// truncateTableData intelligently truncates table cells to fit within terminal width
+func truncateTableData(data pterm.TableData, termWidth int) pterm.TableData {
+	if len(data) == 0 {
+		return data
+	}
+
+	numCols := len(data[0])
+	if numCols == 0 {
+		return data
+	}
+
+	// Calculate separator space: " | " between each column (3 chars per separator)
+	separatorSpace := (numCols - 1) * 3
+
+	// Define minimum column widths (these are the bare minimum before aggressive truncation)
+	minWidths := make([]int, numCols)
+	for i := 0; i < numCols; i++ {
+		minWidths[i] = 8 // minimum 8 chars per column
+	}
+
+	// Calculate natural widths (what each column would want)
+	naturalWidths := make([]int, numCols)
+	for colIdx := 0; colIdx < numCols; colIdx++ {
+		maxWidth := 0
+		for _, row := range data {
+			if colIdx < len(row) {
+				cellWidth := utf8.RuneCountInString(row[colIdx])
+				if cellWidth > maxWidth {
+					maxWidth = cellWidth
+				}
+			}
+		}
+		naturalWidths[colIdx] = maxWidth
+	}
+
+	// Calculate available space for content
+	availableWidth := termWidth - separatorSpace - 2 // -2 for margins
+
+	// Distribute width among columns
+	columnWidths := distributeColumnWidths(naturalWidths, minWidths, availableWidth)
+
+	// Truncate cells based on calculated widths
+	result := make(pterm.TableData, len(data))
+	for rowIdx, row := range data {
+		result[rowIdx] = make([]string, len(row))
+		for colIdx, cell := range row {
+			if colIdx < len(columnWidths) {
+				result[rowIdx][colIdx] = truncateCell(cell, columnWidths[colIdx])
+			} else {
+				result[rowIdx][colIdx] = cell
+			}
+		}
+	}
+
+	return result
+}
+
+// distributeColumnWidths calculates optimal width for each column
+// The first column (typically ID) is always given its full natural width and never truncated
+func distributeColumnWidths(naturalWidths, minWidths []int, availableWidth int) []int {
+	numCols := len(naturalWidths)
+	result := make([]int, numCols)
+
+	// Start with natural widths
+	copy(result, naturalWidths)
+
+	// Calculate total natural width needed
+	totalNatural := 0
+	for _, w := range naturalWidths {
+		totalNatural += w
+	}
+
+	// If natural widths fit, use them
+	if totalNatural <= availableWidth {
+		return result
+	}
+
+	// Priority: Always give the first column its full natural width
+	if numCols > 0 {
+		result[0] = naturalWidths[0]
+		availableWidth -= naturalWidths[0]
+	}
+
+	// Now distribute remaining width among other columns (excluding first)
+	if numCols <= 1 {
+		return result
+	}
+
+	// Calculate needs for non-first columns
+	otherCols := numCols - 1
+	totalMinForOthers := 0
+	totalNaturalForOthers := 0
+	for i := 1; i < numCols; i++ {
+		totalMinForOthers += minWidths[i]
+		totalNaturalForOthers += naturalWidths[i]
+	}
+
+	if totalNaturalForOthers <= availableWidth {
+		// Other columns fit naturally
+		for i := 1; i < numCols; i++ {
+			result[i] = naturalWidths[i]
+		}
+		return result
+	}
+
+	if totalMinForOthers > availableWidth {
+		// Even minimums don't fit for other columns, distribute equally
+		for i := 1; i < numCols; i++ {
+			result[i] = availableWidth / otherCols
+			if result[i] < 5 {
+				result[i] = 5 // absolute minimum
+			}
+		}
+		return result
+	}
+
+	// Give other columns minimum, then distribute remainder proportionally
+	remainingWidth := availableWidth - totalMinForOthers
+	remainingNeed := totalNaturalForOthers - totalMinForOthers
+
+	for i := 1; i < numCols; i++ {
+		result[i] = minWidths[i]
+		if remainingNeed > 0 {
+			additionalNeed := naturalWidths[i] - minWidths[i]
+			additionalGrant := (additionalNeed * remainingWidth) / remainingNeed
+			result[i] += additionalGrant
+		}
+	}
+
+	return result
+}
+
+// truncateCell truncates a cell to maxWidth, adding "..." if truncated
+func truncateCell(cell string, maxWidth int) string {
+	cellWidth := utf8.RuneCountInString(cell)
+	if cellWidth <= maxWidth {
+		return cell
+	}
+
+	if maxWidth <= 3 {
+		// Too narrow for "...", just truncate
+		return truncateString(cell, maxWidth)
+	}
+
+	// Truncate and add "..."
+	return truncateString(cell, maxWidth-3) + "..."
+}
+
+// truncateString truncates a string to the specified number of runes
+func truncateString(s string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return ""
+	}
+
+	runes := []rune(s)
+	if len(runes) <= maxRunes {
+		return s
+	}
+
+	return string(runes[:maxRunes])
 }


### PR DESCRIPTION
Detecting terminal size, use smart column truncation. Seek to avoid truncating shorter columns.

<img width="3420" height="460" alt="image" src="https://github.com/user-attachments/assets/f0e434cc-a0a3-498c-a82f-4845449c0d90" />
