### PR TITLE
live view / screenshots in terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ Create an API key from the [Kernel dashboard](https://dashboard.onkernel.com).
 - `kernel browsers delete <id>` - Delete a browser
   - `-y, --yes` - Skip confirmation prompt
 - `kernel browsers view <id>` - Get live view URL for a browser
+  - `--live` - Show live terminal view of browser (requires iTerm2, Kitty, or Ghostty)
+  - `--interval <duration>` - Refresh interval for live view (default: 100ms)
 
 ### Browser Pools
 
@@ -302,7 +304,8 @@ Create an API key from the [Kernel dashboard](https://dashboard.onkernel.com).
   - `--y <coordinate>` - Y coordinate (required)
   - `--hold-key <key>` - Modifier keys to hold (repeatable)
 - `kernel browsers computer screenshot <id>` - Capture a screenshot
-  - `--to <path>` - Output file path for the PNG image (required)
+  - `--to <path>` - Output file path for the PNG image
+  - `--display` - Display screenshot inline in terminal (requires iTerm2, Kitty, or Ghostty)
   - `--x <coordinate>` - Top-left X for region capture (optional)
   - `--y <coordinate>` - Top-left Y for region capture (optional)
   - `--width <pixels>` - Region width (optional)
@@ -459,6 +462,12 @@ kernel browsers delete browser123 --yes
 # Get live view URL
 kernel browsers view browser123
 
+# Show live view in terminal (iTerm2, Kitty, or Ghostty) - press Ctrl+C to exit
+kernel browsers view browser123 --live
+
+# Show live view with custom refresh rate
+kernel browsers view browser123 --live --interval 200ms
+
 # Stream browser logs
 kernel browsers logs stream my-browser --source supervisor --follow --supervisor-process chromium
 
@@ -483,11 +492,17 @@ kernel browsers computer click-mouse my-browser --x 100 --y 200 --num-clicks 2 -
 # Move the mouse to coordinates (500, 300)
 kernel browsers computer move-mouse my-browser --x 500 --y 300
 
-# Take a full screenshot
+# Take a full screenshot and save to file
 kernel browsers computer screenshot my-browser --to screenshot.png
 
 # Take a screenshot of a specific region
 kernel browsers computer screenshot my-browser --to region.png --x 0 --y 0 --width 800 --height 600
+
+# Display screenshot inline in terminal (iTerm2, Kitty, or Ghostty)
+kernel browsers computer screenshot my-browser --display
+
+# Display and save screenshot
+kernel browsers computer screenshot my-browser --display --to screenshot.png
 
 # Type text in the browser
 kernel browsers computer type my-browser --text "Hello, World!"

--- a/cmd/browsers.go
+++ b/cmd/browsers.go
@@ -503,9 +503,9 @@ func (b BrowsersCmd) LiveView(ctx context.Context, in BrowsersViewInput) error {
 		return util.CleanedUpSdkError{Err: err}
 	}
 
-	// Set default interval if not specified
+	// Set default interval if not specified or invalid
 	interval := in.Interval
-	if interval == 0 {
+	if interval <= 0 {
 		interval = 100 * time.Millisecond
 	}
 
@@ -828,8 +828,13 @@ func (b BrowsersCmd) ComputerScreenshot(ctx context.Context, in BrowsersComputer
 	// Display inline in terminal if requested
 	if in.Display {
 		if err := termimg.DisplayImage(os.Stdout, imgData); err != nil {
-			pterm.Error.Printf("Failed to display screenshot: %v\n", err)
-			return nil
+			// If --to was also specified, warn but continue to save the file
+			if in.To != "" {
+				pterm.Warning.Printf("Failed to display screenshot: %v\n", err)
+			} else {
+				pterm.Error.Printf("Failed to display screenshot: %v\n", err)
+				return nil
+			}
 		}
 	}
 

--- a/cmd/browsers_test.go
+++ b/cmd/browsers_test.go
@@ -357,6 +357,108 @@ func TestBrowsersView_PrintsErrorOnGetFailure(t *testing.T) {
 	assert.Contains(t, err.Error(), "get error")
 }
 
+func TestBrowsersLiveView_RequiresComputerService(t *testing.T) {
+	setupStdoutCapture(t)
+
+	fake := &FakeBrowsersService{
+		GetFunc: func(ctx context.Context, id string, opts ...option.RequestOption) (*kernel.BrowserGetResponse, error) {
+			return &kernel.BrowserGetResponse{SessionID: "abc"}, nil
+		},
+	}
+	// No computer service
+	b := BrowsersCmd{browsers: fake, computer: nil}
+	_ = b.View(context.Background(), BrowsersViewInput{Identifier: "abc", Live: true})
+
+	out := outBuf.String()
+	assert.Contains(t, out, "computer service not available")
+}
+
+func TestBrowsersLiveView_RequiresTerminalSupport(t *testing.T) {
+	setupStdoutCapture(t)
+
+	// Unset terminal env vars to simulate unsupported terminal
+	origTermProgram := os.Getenv("TERM_PROGRAM")
+	origKittyID := os.Getenv("KITTY_WINDOW_ID")
+	defer func() {
+		os.Setenv("TERM_PROGRAM", origTermProgram)
+		os.Setenv("KITTY_WINDOW_ID", origKittyID)
+	}()
+	os.Unsetenv("TERM_PROGRAM")
+	os.Unsetenv("KITTY_WINDOW_ID")
+
+	fake := &FakeBrowsersService{
+		GetFunc: func(ctx context.Context, id string, opts ...option.RequestOption) (*kernel.BrowserGetResponse, error) {
+			return &kernel.BrowserGetResponse{SessionID: "abc"}, nil
+		},
+	}
+	fakeComp := &FakeComputerService{}
+	b := BrowsersCmd{browsers: fake, computer: fakeComp}
+	_ = b.View(context.Background(), BrowsersViewInput{Identifier: "abc", Live: true})
+
+	out := outBuf.String()
+	assert.Contains(t, out, "Terminal does not support inline images")
+}
+
+func TestBrowsersLiveView_ExitsOnCancelledContext(t *testing.T) {
+	setupStdoutCapture(t)
+
+	// Set up terminal support
+	origTermProgram := os.Getenv("TERM_PROGRAM")
+	origKittyID := os.Getenv("KITTY_WINDOW_ID")
+	defer func() {
+		os.Setenv("TERM_PROGRAM", origTermProgram)
+		os.Setenv("KITTY_WINDOW_ID", origKittyID)
+	}()
+	os.Setenv("TERM_PROGRAM", "ghostty")
+	os.Unsetenv("KITTY_WINDOW_ID")
+
+	fake := &FakeBrowsersService{
+		GetFunc: func(ctx context.Context, id string, opts ...option.RequestOption) (*kernel.BrowserGetResponse, error) {
+			return &kernel.BrowserGetResponse{SessionID: "abc"}, nil
+		},
+	}
+
+	screenshotCount := 0
+	fakeComp := &FakeComputerService{
+		CaptureScreenshotFunc: func(ctx context.Context, id string, body kernel.BrowserComputerCaptureScreenshotParams, opts ...option.RequestOption) (*http.Response, error) {
+			screenshotCount++
+			// Return a simple PNG-like response
+			return &http.Response{
+				StatusCode: 200,
+				Header:     http.Header{"Content-Type": []string{"image/png"}},
+				Body:       io.NopCloser(strings.NewReader("fake-png-data")),
+			}, nil
+		},
+	}
+
+	b := BrowsersCmd{browsers: fake, computer: fakeComp}
+
+	// Create a context that we'll cancel immediately after first frame
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Run in goroutine and cancel after a short delay
+	done := make(chan struct{})
+	go func() {
+		_ = b.View(ctx, BrowsersViewInput{Identifier: "abc", Live: true, Interval: 50 * time.Millisecond})
+		close(done)
+	}()
+
+	// Wait a bit for first frame, then cancel
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	// Wait for view to exit
+	select {
+	case <-done:
+		// Success - view exited
+	case <-time.After(2 * time.Second):
+		t.Fatal("LiveView did not exit after context cancellation")
+	}
+
+	// Should have captured at least one screenshot
+	assert.GreaterOrEqual(t, screenshotCount, 1)
+}
+
 func TestBrowsersGet_PrintsDetails(t *testing.T) {
 	setupStdoutCapture(t)
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/boyter/gocodewalker v1.4.0
 	github.com/charmbracelet/fang v0.2.0
+	github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.1
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/joho/godotenv v1.5.1
 	github.com/onkernel/kernel-go-sdk v0.21.0
@@ -25,7 +26,6 @@ require (
 	atomicgo.dev/keyboard v0.2.9 // indirect
 	atomicgo.dev/schedule v0.1.0 // indirect
 	github.com/charmbracelet/colorprofile v0.3.0 // indirect
-	github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.1 // indirect
 	github.com/charmbracelet/x/ansi v0.8.0 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/charmtone v0.0.0-20250603201427-c31516f43444 // indirect

--- a/pkg/termimg/termimg.go
+++ b/pkg/termimg/termimg.go
@@ -3,6 +3,7 @@
 package termimg
 
 import (
+	"bytes"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -89,6 +90,127 @@ func DisplayImage(w io.Writer, img []byte) error {
 	}
 }
 
+// ANSI escape sequences for cursor and screen control
+const (
+	cursorHide    = "\033[?25l"
+	cursorShow    = "\033[?25h"
+	cursorHome    = "\033[H"
+	clearToEnd    = "\033[J"
+	clearScreen   = "\033[2J"
+	saveCursor    = "\033[s"
+	restoreCursor = "\033[u"
+
+	// Synchronized output mode (supported by Kitty, Ghostty, and others)
+	// Buffers all output and renders atomically to prevent flicker
+	syncStart = "\033[?2026h"
+	syncEnd   = "\033[?2026l"
+)
+
+// HideCursor hides the terminal cursor.
+func HideCursor(w io.Writer) {
+	fmt.Fprint(w, cursorHide)
+}
+
+// ShowCursor shows the terminal cursor.
+func ShowCursor(w io.Writer) {
+	fmt.Fprint(w, cursorShow)
+}
+
+// ClearScreen clears the entire screen and moves cursor to home position.
+func ClearScreen(w io.Writer) {
+	fmt.Fprint(w, cursorHome+clearScreen)
+}
+
+// ClearAndDisplayImage clears the screen and displays an image at the top.
+// This is used for animation/live view to replace the previous frame.
+func ClearAndDisplayImage(w io.Writer, img []byte) error {
+	term := DetectTerminal()
+	switch term {
+	case TerminaliTerm2:
+		// For iTerm2: move cursor home, clear screen, then draw
+		fmt.Fprint(w, cursorHome+clearToEnd)
+		return displayiTerm2(w, img)
+	case TerminalKitty, TerminalGhostty:
+		// For Kitty: delete previous image by ID, then draw new one with same ID
+		return displayKittyFrame(w, img)
+	default:
+		return fmt.Errorf("terminal does not support inline images (detected: %s). Try using iTerm2, Kitty, or Ghostty", term)
+	}
+}
+
+// liveViewImageID is the placement ID used for live view frames
+const liveViewImageID = 1
+
+// displayKittyFrame displays an image for live view, replacing any previous frame.
+// Uses synchronized output mode to prevent flicker - all drawing is buffered
+// and rendered atomically.
+func displayKittyFrame(w io.Writer, img []byte) error {
+	encoded := base64.StdEncoding.EncodeToString(img)
+	cols, _ := getTerminalSize()
+
+	// Buffer all output to write in one go
+	var buf bytes.Buffer
+
+	// Start synchronized output mode - terminal buffers all changes
+	buf.WriteString(syncStart)
+
+	// Delete the previous frame with this ID (ignore if none exists)
+	// a=d means delete, d=i means delete by image ID, i=ID specifies the ID
+	// q=2 quiet mode - suppress response
+	fmt.Fprintf(&buf, "\033_Ga=d,d=i,q=2,i=%d\033\\", liveViewImageID)
+
+	// Move cursor to home position for consistent placement
+	buf.WriteString(cursorHome)
+
+	const chunkSize = 4096
+
+	for i := 0; i < len(encoded); i += chunkSize {
+		end := i + chunkSize
+		if end > len(encoded) {
+			end = len(encoded)
+		}
+		chunk := encoded[i:end]
+
+		more := 1
+		if end >= len(encoded) {
+			more = 0
+		}
+
+		if i == 0 {
+			// First chunk: include all parameters
+			// a=T transmit and display, f=100 PNG, i=ID placement ID, c=cols width
+			// q=2 quiet mode - suppress response to avoid printing "_Gi=1;OK" garbage
+			fmt.Fprintf(&buf, "\033_Ga=T,q=2,f=100,i=%d,c=%d,m=%d;%s\033\\", liveViewImageID, cols, more, chunk)
+		} else {
+			fmt.Fprintf(&buf, "\033_Gm=%d;%s\033\\", more, chunk)
+		}
+	}
+
+	// End synchronized output mode - terminal renders everything atomically
+	buf.WriteString(syncEnd)
+
+	// Write everything in one go
+	_, err := w.Write(buf.Bytes())
+	return err
+}
+
+// CleanupLiveView cleans up after a live view session.
+// It shows the cursor and optionally clears the last frame.
+func CleanupLiveView(w io.Writer, clearImage bool) {
+	term := DetectTerminal()
+
+	// For Kitty/Ghostty, delete the live view image
+	if clearImage && (term == TerminalKitty || term == TerminalGhostty) {
+		fmt.Fprintf(w, "\033_Ga=d,d=i,q=2,i=%d\033\\", liveViewImageID)
+	}
+
+	// Show cursor again
+	ShowCursor(w)
+
+	// Print newline to ensure prompt appears on clean line
+	fmt.Fprintln(w)
+}
+
 // displayiTerm2 renders an image using iTerm2's inline images protocol.
 // Protocol: ESC ] 1337 ; File = [args] : base64data BEL
 // https://iterm2.com/documentation-images.html
@@ -107,6 +229,9 @@ func displayiTerm2(w io.Writer, img []byte) error {
 func displayKitty(w io.Writer, img []byte) error {
 	encoded := base64.StdEncoding.EncodeToString(img)
 
+	// Get terminal width to scale image appropriately
+	cols, _ := getTerminalSize()
+
 	// Kitty requires chunked transmission for data over 4096 bytes
 	const chunkSize = 4096
 
@@ -120,13 +245,15 @@ func displayKitty(w io.Writer, img []byte) error {
 		// m=1 means more chunks coming, m=0 means last chunk
 		// a=T means transmit and display
 		// f=100 means PNG format (also works for JPEG)
+		// c=cols means display width in terminal columns
+		// q=2 quiet mode - suppress response to avoid printing garbage
 		if i == 0 {
 			// First chunk includes all the parameters
 			more := 1
 			if end >= len(encoded) {
 				more = 0
 			}
-			_, err := fmt.Fprintf(w, "\033_Ga=T,f=100,m=%d;%s\033\\", more, chunk)
+			_, err := fmt.Fprintf(w, "\033_Ga=T,q=2,f=100,c=%d,m=%d;%s\033\\", cols, more, chunk)
 			if err != nil {
 				return err
 			}

--- a/pkg/termimg/termimg.go
+++ b/pkg/termimg/termimg.go
@@ -1,0 +1,149 @@
+// Package termimg provides utilities for displaying images inline in terminal emulators.
+// It supports iTerm2 and Kitty graphics protocols.
+package termimg
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+
+	"golang.org/x/term"
+)
+
+// TerminalType represents the type of terminal emulator.
+type TerminalType int
+
+const (
+	TerminalUnknown TerminalType = iota
+	TerminaliTerm2
+	TerminalKitty
+	TerminalGhostty
+)
+
+func (t TerminalType) String() string {
+	switch t {
+	case TerminaliTerm2:
+		return "iTerm2"
+	case TerminalKitty:
+		return "Kitty"
+	case TerminalGhostty:
+		return "Ghostty"
+	default:
+		return "Unknown"
+	}
+}
+
+// DetectTerminal returns the type of terminal emulator based on environment variables.
+func DetectTerminal() TerminalType {
+	termProgram := os.Getenv("TERM_PROGRAM")
+	// Check for iTerm2
+	if termProgram == "iTerm.app" {
+		return TerminaliTerm2
+	}
+	// Check for Ghostty (uses Kitty graphics protocol)
+	if termProgram == "ghostty" {
+		return TerminalGhostty
+	}
+	// Check for Kitty
+	if os.Getenv("KITTY_WINDOW_ID") != "" {
+		return TerminalKitty
+	}
+	return TerminalUnknown
+}
+
+// IsSupported returns true if the current terminal supports inline image display.
+func IsSupported() bool {
+	return DetectTerminal() != TerminalUnknown
+}
+
+// getTerminalSize returns the terminal width and height in columns and rows.
+// Returns default values if the size cannot be determined.
+func getTerminalSize() (cols, rows int) {
+	// Default to reasonable values if we can't detect
+	cols, rows = 80, 24
+
+	// Try stdout first, then stdin
+	for _, fd := range []int{int(os.Stdout.Fd()), int(os.Stdin.Fd())} {
+		if term.IsTerminal(fd) {
+			if w, h, err := term.GetSize(fd); err == nil {
+				return w, h
+			}
+		}
+	}
+	return cols, rows
+}
+
+// DisplayImage writes escape sequences to display the given image data inline.
+// The image data should be raw PNG/JPEG bytes.
+func DisplayImage(w io.Writer, img []byte) error {
+	term := DetectTerminal()
+	switch term {
+	case TerminaliTerm2:
+		return displayiTerm2(w, img)
+	case TerminalKitty, TerminalGhostty:
+		// Ghostty uses the Kitty graphics protocol
+		return displayKitty(w, img)
+	default:
+		return fmt.Errorf("terminal does not support inline images (detected: %s). Try using iTerm2, Kitty, or Ghostty, or use --to to save to a file", term)
+	}
+}
+
+// displayiTerm2 renders an image using iTerm2's inline images protocol.
+// Protocol: ESC ] 1337 ; File = [args] : base64data BEL
+// https://iterm2.com/documentation-images.html
+func displayiTerm2(w io.Writer, img []byte) error {
+	encoded := base64.StdEncoding.EncodeToString(img)
+	// inline=1 displays the image inline
+	// width=100% fills terminal width, height=auto preserves aspect ratio
+	// preserveAspectRatio=1 maintains aspect ratio
+	_, err := fmt.Fprintf(w, "\033]1337;File=inline=1;width=100%%;height=auto;preserveAspectRatio=1:%s\a", encoded)
+	return err
+}
+
+// displayKitty renders an image using Kitty's graphics protocol.
+// Protocol uses chunked transmission for large images.
+// https://sw.kovidgoyal.net/kitty/graphics-protocol/
+func displayKitty(w io.Writer, img []byte) error {
+	encoded := base64.StdEncoding.EncodeToString(img)
+
+	// Kitty requires chunked transmission for data over 4096 bytes
+	const chunkSize = 4096
+
+	for i := 0; i < len(encoded); i += chunkSize {
+		end := i + chunkSize
+		if end > len(encoded) {
+			end = len(encoded)
+		}
+		chunk := encoded[i:end]
+
+		// m=1 means more chunks coming, m=0 means last chunk
+		// a=T means transmit and display
+		// f=100 means PNG format (also works for JPEG)
+		if i == 0 {
+			// First chunk includes all the parameters
+			more := 1
+			if end >= len(encoded) {
+				more = 0
+			}
+			_, err := fmt.Fprintf(w, "\033_Ga=T,f=100,m=%d;%s\033\\", more, chunk)
+			if err != nil {
+				return err
+			}
+		} else {
+			// Subsequent chunks only need the 'm' parameter
+			more := 1
+			if end >= len(encoded) {
+				more = 0
+			}
+			_, err := fmt.Fprintf(w, "\033_Gm=%d;%s\033\\", more, chunk)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// Print a newline after the image so subsequent output appears below
+	_, err := fmt.Fprintln(w)
+	return err
+}

--- a/pkg/termimg/termimg_test.go
+++ b/pkg/termimg/termimg_test.go
@@ -120,8 +120,8 @@ func TestDisplayImage_iTerm2(t *testing.T) {
 
 	require.NoError(t, err)
 	output := buf.String()
-	// Should contain iTerm2 escape sequence prefix
-	assert.Contains(t, output, "\033]1337;File=inline=1;width=auto;height=auto;preserveAspectRatio=1:")
+	// Should contain iTerm2 escape sequence with 100% width to fill terminal
+	assert.Contains(t, output, "\033]1337;File=inline=1;width=100%;height=auto;preserveAspectRatio=1:")
 	// Should end with bell character
 	assert.True(t, output[len(output)-1] == '\a')
 }
@@ -143,8 +143,8 @@ func TestDisplayImage_Kitty(t *testing.T) {
 
 	require.NoError(t, err)
 	output := buf.String()
-	// Should contain Kitty escape sequence prefix
-	assert.Contains(t, output, "\033_Ga=T,f=100")
+	// Should contain Kitty escape sequence prefix with quiet mode
+	assert.Contains(t, output, "\033_Ga=T,q=2,f=100")
 }
 
 func TestDisplayImage_Ghostty(t *testing.T) {
@@ -164,8 +164,8 @@ func TestDisplayImage_Ghostty(t *testing.T) {
 
 	require.NoError(t, err)
 	output := buf.String()
-	// Ghostty uses Kitty protocol, should contain Kitty escape sequence prefix
-	assert.Contains(t, output, "\033_Ga=T,f=100")
+	// Ghostty uses Kitty protocol, should contain Kitty escape sequence prefix with quiet mode
+	assert.Contains(t, output, "\033_Ga=T,q=2,f=100")
 }
 
 func TestDisplayImage_Kitty_LargeImage(t *testing.T) {
@@ -193,4 +193,95 @@ func TestDisplayImage_Kitty_LargeImage(t *testing.T) {
 	// Should have multiple chunks indicated by m=1 (more) followed by m=0 (last)
 	assert.Contains(t, output, "m=1")
 	assert.Contains(t, output, "m=0")
+}
+
+func TestHideCursor(t *testing.T) {
+	var buf bytes.Buffer
+	HideCursor(&buf)
+	assert.Equal(t, "\033[?25l", buf.String())
+}
+
+func TestShowCursor(t *testing.T) {
+	var buf bytes.Buffer
+	ShowCursor(&buf)
+	assert.Equal(t, "\033[?25h", buf.String())
+}
+
+func TestClearScreen(t *testing.T) {
+	var buf bytes.Buffer
+	ClearScreen(&buf)
+	assert.Equal(t, "\033[H\033[2J", buf.String())
+}
+
+func TestClearAndDisplayImage_iTerm2(t *testing.T) {
+	origTermProgram := os.Getenv("TERM_PROGRAM")
+	origKittyID := os.Getenv("KITTY_WINDOW_ID")
+	defer func() {
+		os.Setenv("TERM_PROGRAM", origTermProgram)
+		os.Setenv("KITTY_WINDOW_ID", origKittyID)
+	}()
+
+	os.Setenv("TERM_PROGRAM", "iTerm.app")
+	os.Unsetenv("KITTY_WINDOW_ID")
+
+	var buf bytes.Buffer
+	imgData := []byte("test png data")
+	err := ClearAndDisplayImage(&buf, imgData)
+
+	require.NoError(t, err)
+	output := buf.String()
+	// Should start with cursor home and clear
+	assert.True(t, len(output) > 0 && output[0] == '\033')
+	assert.Contains(t, output, "\033[H\033[J")
+	// Should contain iTerm2 image escape
+	assert.Contains(t, output, "\033]1337;File=inline=1")
+}
+
+func TestClearAndDisplayImage_Kitty(t *testing.T) {
+	origTermProgram := os.Getenv("TERM_PROGRAM")
+	origKittyID := os.Getenv("KITTY_WINDOW_ID")
+	defer func() {
+		os.Setenv("TERM_PROGRAM", origTermProgram)
+		os.Setenv("KITTY_WINDOW_ID", origKittyID)
+	}()
+
+	os.Unsetenv("TERM_PROGRAM")
+	os.Setenv("KITTY_WINDOW_ID", "12345")
+
+	var buf bytes.Buffer
+	imgData := []byte("test png data")
+	err := ClearAndDisplayImage(&buf, imgData)
+
+	require.NoError(t, err)
+	output := buf.String()
+	// Should start with synchronized output mode
+	assert.Contains(t, output, "\033[?2026h")
+	// Should contain delete command for previous image (with q=2 quiet mode)
+	assert.Contains(t, output, "\033_Ga=d,d=i,q=2,i=1\033\\")
+	// Should contain Kitty image with placement ID and quiet mode
+	assert.Contains(t, output, "q=2")
+	assert.Contains(t, output, "i=1")
+	// Should end synchronized output mode
+	assert.Contains(t, output, "\033[?2026l")
+}
+
+func TestCleanupLiveView_Kitty(t *testing.T) {
+	origTermProgram := os.Getenv("TERM_PROGRAM")
+	origKittyID := os.Getenv("KITTY_WINDOW_ID")
+	defer func() {
+		os.Setenv("TERM_PROGRAM", origTermProgram)
+		os.Setenv("KITTY_WINDOW_ID", origKittyID)
+	}()
+
+	os.Unsetenv("TERM_PROGRAM")
+	os.Setenv("KITTY_WINDOW_ID", "12345")
+
+	var buf bytes.Buffer
+	CleanupLiveView(&buf, true)
+
+	output := buf.String()
+	// Should delete the image (with q=2 quiet mode)
+	assert.Contains(t, output, "\033_Ga=d,d=i,q=2,i=1\033\\")
+	// Should show cursor
+	assert.Contains(t, output, "\033[?25h")
 }

--- a/pkg/termimg/termimg_test.go
+++ b/pkg/termimg/termimg_test.go
@@ -1,0 +1,196 @@
+package termimg
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTerminalType_String(t *testing.T) {
+	tests := []struct {
+		term     TerminalType
+		expected string
+	}{
+		{TerminalUnknown, "Unknown"},
+		{TerminaliTerm2, "iTerm2"},
+		{TerminalKitty, "Kitty"},
+		{TerminalGhostty, "Ghostty"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, tt.term.String())
+	}
+}
+
+func TestDetectTerminal_iTerm2(t *testing.T) {
+	// Save and restore env vars
+	origTermProgram := os.Getenv("TERM_PROGRAM")
+	origKittyID := os.Getenv("KITTY_WINDOW_ID")
+	defer func() {
+		os.Setenv("TERM_PROGRAM", origTermProgram)
+		os.Setenv("KITTY_WINDOW_ID", origKittyID)
+	}()
+
+	os.Setenv("TERM_PROGRAM", "iTerm.app")
+	os.Unsetenv("KITTY_WINDOW_ID")
+
+	assert.Equal(t, TerminaliTerm2, DetectTerminal())
+	assert.True(t, IsSupported())
+}
+
+func TestDetectTerminal_Kitty(t *testing.T) {
+	origTermProgram := os.Getenv("TERM_PROGRAM")
+	origKittyID := os.Getenv("KITTY_WINDOW_ID")
+	defer func() {
+		os.Setenv("TERM_PROGRAM", origTermProgram)
+		os.Setenv("KITTY_WINDOW_ID", origKittyID)
+	}()
+
+	os.Unsetenv("TERM_PROGRAM")
+	os.Setenv("KITTY_WINDOW_ID", "12345")
+
+	assert.Equal(t, TerminalKitty, DetectTerminal())
+	assert.True(t, IsSupported())
+}
+
+func TestDetectTerminal_Ghostty(t *testing.T) {
+	origTermProgram := os.Getenv("TERM_PROGRAM")
+	origKittyID := os.Getenv("KITTY_WINDOW_ID")
+	defer func() {
+		os.Setenv("TERM_PROGRAM", origTermProgram)
+		os.Setenv("KITTY_WINDOW_ID", origKittyID)
+	}()
+
+	os.Setenv("TERM_PROGRAM", "ghostty")
+	os.Unsetenv("KITTY_WINDOW_ID")
+
+	assert.Equal(t, TerminalGhostty, DetectTerminal())
+	assert.True(t, IsSupported())
+}
+
+func TestDetectTerminal_Unknown(t *testing.T) {
+	origTermProgram := os.Getenv("TERM_PROGRAM")
+	origKittyID := os.Getenv("KITTY_WINDOW_ID")
+	defer func() {
+		os.Setenv("TERM_PROGRAM", origTermProgram)
+		os.Setenv("KITTY_WINDOW_ID", origKittyID)
+	}()
+
+	os.Unsetenv("TERM_PROGRAM")
+	os.Unsetenv("KITTY_WINDOW_ID")
+
+	assert.Equal(t, TerminalUnknown, DetectTerminal())
+	assert.False(t, IsSupported())
+}
+
+func TestDisplayImage_UnsupportedTerminal(t *testing.T) {
+	origTermProgram := os.Getenv("TERM_PROGRAM")
+	origKittyID := os.Getenv("KITTY_WINDOW_ID")
+	defer func() {
+		os.Setenv("TERM_PROGRAM", origTermProgram)
+		os.Setenv("KITTY_WINDOW_ID", origKittyID)
+	}()
+
+	os.Unsetenv("TERM_PROGRAM")
+	os.Unsetenv("KITTY_WINDOW_ID")
+
+	var buf bytes.Buffer
+	err := DisplayImage(&buf, []byte("fake image data"))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "terminal does not support inline images")
+}
+
+func TestDisplayImage_iTerm2(t *testing.T) {
+	origTermProgram := os.Getenv("TERM_PROGRAM")
+	origKittyID := os.Getenv("KITTY_WINDOW_ID")
+	defer func() {
+		os.Setenv("TERM_PROGRAM", origTermProgram)
+		os.Setenv("KITTY_WINDOW_ID", origKittyID)
+	}()
+
+	os.Setenv("TERM_PROGRAM", "iTerm.app")
+	os.Unsetenv("KITTY_WINDOW_ID")
+
+	var buf bytes.Buffer
+	imgData := []byte("test png data")
+	err := DisplayImage(&buf, imgData)
+
+	require.NoError(t, err)
+	output := buf.String()
+	// Should contain iTerm2 escape sequence prefix
+	assert.Contains(t, output, "\033]1337;File=inline=1;width=auto;height=auto;preserveAspectRatio=1:")
+	// Should end with bell character
+	assert.True(t, output[len(output)-1] == '\a')
+}
+
+func TestDisplayImage_Kitty(t *testing.T) {
+	origTermProgram := os.Getenv("TERM_PROGRAM")
+	origKittyID := os.Getenv("KITTY_WINDOW_ID")
+	defer func() {
+		os.Setenv("TERM_PROGRAM", origTermProgram)
+		os.Setenv("KITTY_WINDOW_ID", origKittyID)
+	}()
+
+	os.Unsetenv("TERM_PROGRAM")
+	os.Setenv("KITTY_WINDOW_ID", "12345")
+
+	var buf bytes.Buffer
+	imgData := []byte("test png data")
+	err := DisplayImage(&buf, imgData)
+
+	require.NoError(t, err)
+	output := buf.String()
+	// Should contain Kitty escape sequence prefix
+	assert.Contains(t, output, "\033_Ga=T,f=100")
+}
+
+func TestDisplayImage_Ghostty(t *testing.T) {
+	origTermProgram := os.Getenv("TERM_PROGRAM")
+	origKittyID := os.Getenv("KITTY_WINDOW_ID")
+	defer func() {
+		os.Setenv("TERM_PROGRAM", origTermProgram)
+		os.Setenv("KITTY_WINDOW_ID", origKittyID)
+	}()
+
+	os.Setenv("TERM_PROGRAM", "ghostty")
+	os.Unsetenv("KITTY_WINDOW_ID")
+
+	var buf bytes.Buffer
+	imgData := []byte("test png data")
+	err := DisplayImage(&buf, imgData)
+
+	require.NoError(t, err)
+	output := buf.String()
+	// Ghostty uses Kitty protocol, should contain Kitty escape sequence prefix
+	assert.Contains(t, output, "\033_Ga=T,f=100")
+}
+
+func TestDisplayImage_Kitty_LargeImage(t *testing.T) {
+	origTermProgram := os.Getenv("TERM_PROGRAM")
+	origKittyID := os.Getenv("KITTY_WINDOW_ID")
+	defer func() {
+		os.Setenv("TERM_PROGRAM", origTermProgram)
+		os.Setenv("KITTY_WINDOW_ID", origKittyID)
+	}()
+
+	os.Unsetenv("TERM_PROGRAM")
+	os.Setenv("KITTY_WINDOW_ID", "12345")
+
+	var buf bytes.Buffer
+	// Create data that will result in > 4096 bytes when base64 encoded
+	// (4096 * 3/4 = 3072 raw bytes, so use more)
+	imgData := make([]byte, 5000)
+	for i := range imgData {
+		imgData[i] = byte(i % 256)
+	}
+	err := DisplayImage(&buf, imgData)
+
+	require.NoError(t, err)
+	output := buf.String()
+	// Should have multiple chunks indicated by m=1 (more) followed by m=0 (last)
+	assert.Contains(t, output, "m=1")
+	assert.Contains(t, output, "m=0")
+}


### PR DESCRIPTION
because why not


https://github.com/user-attachments/assets/85aab0c5-b392-48ba-8b1b-5449a0e6c8c1


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a live terminal view for browsers and enables inline screenshot display, with terminal image support for iTerm2/Kitty/Ghostty.
> 
> - **CLI – Browsers**:
>   - `kernel browsers view <id>`: new `--live` terminal view with `--interval` refresh; graceful signal-based exit and frame rendering.
>   - `kernel browsers computer screenshot <id>`: add `--display` to show inline; `--to` now optional; support display-and-save; improved region validation.
> - **Terminal image support**:
>   - New package `pkg/termimg`: detect terminal (iTerm2/Kitty/Ghostty), render images (Kitty/iTerm2 protocols), live frame replace, cursor/screen control, cleanup helpers.
> - **Docs**:
>   - Update `README.md` with `--live`, `--interval`, and `--display` usage and examples.
> - **Tests**:
>   - Extensive unit tests for live view, terminal detection, image rendering, and screenshot behaviors.
> - **Deps**:
>   - Promote `github.com/charmbracelet/lipgloss/v2` to direct dependency in `go.mod`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2fae27042c2ef038684ddce3bda5eed8f57e5385. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->