### PR TITLE
Add singular alias for auth connections subcommand

### DIFF
--- a/cmd/auth_connections.go
+++ b/cmd/auth_connections.go
@@ -711,9 +711,10 @@ func (c AuthConnectionCmd) Follow(ctx context.Context, in AuthConnectionFollowIn
 // --- Cobra wiring ---
 
 var authConnectionsCmd = &cobra.Command{
-	Use:   "connections",
-	Short: "Manage auth connections (managed auth)",
-	Long:  "Commands for managing authentication connections that keep profiles logged into domains",
+	Use:     "connections",
+	Aliases: []string{"connection"},
+	Short:   "Manage auth connections (managed auth)",
+	Long:    "Commands for managing authentication connections that keep profiles logged into domains",
 }
 
 var authConnectionsCreateCmd = &cobra.Command{


### PR DESCRIPTION
## Summary
- Add `connection` as an alias for the `connections` subcommand under `kernel auth`, so `kernel auth connection list` works alongside `kernel auth connections list`
- This was the only resource command missing a singular/plural alias — all others already had both forms

## Context
Every other resource command in the CLI already supports both singular and plural:
- `browsers` / `browser`
- `browser-pools` / `browser-pool` / `pool` / `pools`
- `app` / `apps`
- `profiles` / `profile`
- `proxies` / `proxy`
- `extensions` / `extension`
- `credentials` / `credential` / `creds` / `cred`
- `credential-providers` / `credential-provider` / `cred-providers` / `cred-provider`
- `logs` / `log`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./cmd/...` passes