### PR TITLE
fix: add missing gitignore files for cua templates

### DIFF
--- a/pkg/templates/python/cua/_gitignore
+++ b/pkg/templates/python/cua/_gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+.env
+.venv/
+env/

--- a/pkg/templates/typescript/cua/_gitignore
+++ b/pkg/templates/typescript/cua/_gitignore
@@ -1,0 +1,2 @@
+node_modules
+bun.lockb


### PR DESCRIPTION
Add the standard template _gitignore files for the new TypeScript and Python CUA templates so generated apps include .gitignore and the template tests pass again.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only adds template ignore patterns and does not affect runtime logic or production behavior.
> 
> **Overview**
> Adds `_gitignore` files to the Python and TypeScript `cua` templates so generated apps include a `.gitignore` with standard ignores (e.g., Python virtualenv/cache folders and TypeScript `node_modules`/`bun.lockb`), restoring expected template/test behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e46a020df086971e6992d3e4ffd09b60423073f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->