### PR TITLE
Skip column truncation when stdout is piped (non-TTY)

### DIFF
--- a/cmd/browsers.go
+++ b/cmd/browsers.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/kernel/cli/pkg/table"
 	"github.com/kernel/cli/pkg/util"
 	"github.com/kernel/kernel-go-sdk"
 	"github.com/kernel/kernel-go-sdk/option"
@@ -3256,6 +3257,9 @@ func runBrowsersComputerWriteClipboard(cmd *cobra.Command, args []string) error 
 }
 
 func truncateURL(url string, maxLen int) string {
+	if !table.IsStdoutTTY() {
+		return url
+	}
 	if len(url) <= maxLen {
 		return url
 	}

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -1,10 +1,12 @@
 package table
 
 import (
+	"os"
 	"strings"
 	"unicode/utf8"
 
 	"github.com/pterm/pterm"
+	"golang.org/x/term"
 )
 
 // PrintTableNoPad renders a table similar to pterm.DefaultTable, but it avoids
@@ -17,12 +19,15 @@ func PrintTableNoPad(data pterm.TableData, hasHeader bool) {
 		return
 	}
 
-	// Get terminal width and truncate data to fit
-	termWidth := pterm.GetTerminalWidth()
-	if termWidth <= 0 {
-		termWidth = 80 // fallback
+	// Only truncate columns when outputting to a terminal.
+	// When piped (non-TTY), output full values so grep/awk/etc. work correctly.
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		termWidth := pterm.GetTerminalWidth()
+		if termWidth <= 0 {
+			termWidth = 80 // fallback
+		}
+		data = truncateTableData(data, termWidth)
 	}
-	data = truncateTableData(data, termWidth)
 
 	// Determine number of columns from the first row
 	numCols := len(data[0])
@@ -88,6 +93,11 @@ func PrintTableNoPad(data pterm.TableData, hasHeader bool) {
 	}
 
 	pterm.Print(b.String())
+}
+
+// IsStdoutTTY reports whether stdout is connected to a terminal.
+func IsStdoutTTY() bool {
+	return term.IsTerminal(int(os.Stdout.Fd()))
 }
 
 // truncateTableData intelligently truncates table cells to fit within terminal width


### PR DESCRIPTION
## Summary

Fixes CLI table output truncation when stdout is piped to other tools (grep, awk, cat, etc.).

**Before:** `kernel browsers list | grep hype` returned nothing because URLs and other columns were truncated even in pipe mode.

**After:**
- TTY (interactive terminal): columns truncate to fit terminal width (unchanged)
- Non-TTY (piped): full column values output without truncation

This follows the standard CLI pattern used by `docker ps`, `kubectl get`, etc.

### Changes
- `pkg/table/table.go`: Skip `truncateTableData` when stdout is not a TTY; add `IsStdoutTTY()` helper
- `cmd/browsers.go`: `truncateURL` skips truncation in non-TTY mode

## Test plan

- [ ] `kernel browsers list` in terminal — columns still truncate to fit width
- [ ] `kernel browsers list | cat` — full URLs visible, no truncation
- [ ] `kernel browsers list | grep <pattern>` — matches found in full output
- [ ] All existing tests pass (`go test ./...`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CLI formatting behavior and only affect output when stdout is not a terminal (piped), with no impact on API calls or data mutation.
> 
> **Overview**
> Stops truncating CLI output when stdout is piped (non-TTY) so full column values are preserved for tools like `grep`/`awk`.
> 
> `pkg/table.PrintTableNoPad` now truncates columns only for terminal output and adds a shared `table.IsStdoutTTY()` helper; `cmd/browsers.go`’s `truncateURL` also skips truncation when not on a TTY.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b00381065c94a59cd039a87f1e0869d1f5f275d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->