### PR TITLE
ci: add Semgrep SAST scanning on pull requests

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,17 @@
+name: Semgrep
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  scan:
+    uses: kernel/security-workflows/.github/workflows/semgrep.yml@main
+    with:
+      extra-configs: '--config p/golang --config p/trailofbits'
+      codebase-description: 'Kernel CLI tool authenticating with customer API keys'
+    secrets: inherit

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,5 @@
+node_modules/
+vendor/
+dist/
+*_test.go
+go.sum


### PR DESCRIPTION
Adds Semgrep static analysis on PRs to main via the reusable workflow in kernel/security-workflows. Includes .semgrepignore for generated code, test fixtures, and lock files.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds a new PR workflow; main risk is potential noisy findings or CI time/permissions issues.
> 
> **Overview**
> Adds a new GitHub Actions workflow `semgrep.yml` to run Semgrep SAST on pull requests to `main` via the reusable `kernel/security-workflows` workflow, configured with the `p/golang` and `p/trailofbits` rulesets.
> 
> Introduces `.semgrepignore` to exclude common generated/dependency artifacts and test files (`node_modules/`, `vendor/`, `dist/`, `*_test.go`, `go.sum`) from scanning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f53190299a3c3bf909444208cdc28361e748223. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->