### PR TITLE
Add Tzafon, Yutori, and OpenAGI providers to unified CUA

### DIFF
--- a/pkg/create/templates.go
+++ b/pkg/create/templates.go
@@ -94,7 +94,7 @@ var Templates = map[string]TemplateInfo{
 	},
 	TemplateUnifiedCUA: {
 		Name:        "Unified CUA",
-		Description: "Multi-provider computer use agent with Anthropic/OpenAI/Gemini fallback",
+		Description: "Multi-provider computer use agent with Anthropic/OpenAI/Gemini/Tzafon/Yutori/OpenAGI fallback",
 		Languages:   []string{LanguageTypeScript, LanguagePython},
 	},
 	TemplateTzafonComputerUse: {

--- a/pkg/templates/python/cua/.env.example
+++ b/pkg/templates/python/cua/.env.example
@@ -1,7 +1,7 @@
 # Copy this file to .env and fill in your API keys.
 # Only the key for your chosen provider is required.
 
-# Primary provider: "anthropic", "openai", or "gemini"
+# Primary provider: "anthropic", "openai", "gemini", "tzafon", "yutori", or "openagi"
 CUA_PROVIDER=anthropic
 
 # Comma-separated fallback order (optional).
@@ -12,6 +12,9 @@ CUA_PROVIDER=anthropic
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
 OPENAI_API_KEY=your_openai_api_key_here
 GOOGLE_API_KEY=your_google_api_key_here
+TZAFON_API_KEY=your_tzafon_api_key_here
+YUTORI_API_KEY=your_yutori_api_key_here
+OAGI_API_KEY=your_openagi_api_key_here
 
 # Browser config (proxy, profile, extensions, timeout) is set per-request
 # via the payload "browser" field, not here. Example:

--- a/pkg/templates/python/cua/README.md
+++ b/pkg/templates/python/cua/README.md
@@ -1,6 +1,6 @@
 # Unified CUA Template
 
-A multi-provider Computer Use Agent (CUA) template for [Kernel](https://kernel.sh). Supports **Anthropic**, **OpenAI**, and **Google Gemini** as interchangeable backends with automatic fallback.
+A multi-provider Computer Use Agent (CUA) template for [Kernel](https://kernel.sh). Supports **Anthropic**, **OpenAI**, **Google Gemini**, **Tzafon**, **Yutori**, and **OpenAGI** as interchangeable backends with automatic fallback.
 
 ## Quick start
 
@@ -26,6 +26,9 @@ Set `CUA_PROVIDER` to your preferred provider and add the matching API key:
 | `anthropic` | `ANTHROPIC_API_KEY` | `claude-sonnet-4-6`                       |
 | `openai`    | `OPENAI_API_KEY`    | `gpt-5.4`                                 |
 | `gemini`    | `GOOGLE_API_KEY`    | `gemini-2.5-computer-use-preview-10-2025` |
+| `tzafon`    | `TZAFON_API_KEY`    | `tzafon.northstar-cua-fast`               |
+| `yutori`    | `YUTORI_API_KEY`    | `n1-latest`                               |
+| `openagi`   | `OAGI_API_KEY`      | `lux-actor-1`                             |
 
 
 ### 3. Deploy to Kernel
@@ -71,6 +74,9 @@ providers/
   anthropic.py        — Anthropic Claude adapter
   openai.py           — OpenAI GPT adapter
   gemini.py           — Google Gemini adapter
+  tzafon.py           — Tzafon Northstar adapter
+  yutori.py           — Yutori n1 adapter
+  openagi.py          — OpenAGI Lux adapter (Python only)
 ```
 
 ## Customization
@@ -85,4 +91,7 @@ To add a new provider, create a new file that implements the `CuaProvider` proto
 - [Anthropic Computer Use](https://docs.anthropic.com/en/docs/agents-and-tools/computer-use)
 - [OpenAI Computer Use](https://platform.openai.com/docs/guides/computer-use)
 - [Google Gemini Computer Use](https://ai.google.dev/gemini-api/docs/computer-use)
+- [Tzafon Lightcone](https://docs.lightcone.ai)
+- [Yutori n1](https://docs.yutori.com/reference/n1)
+- [OpenAGI](https://agiopen.org)
 

--- a/pkg/templates/python/cua/providers/__init__.py
+++ b/pkg/templates/python/cua/providers/__init__.py
@@ -48,6 +48,15 @@ def _build_provider(name: str) -> CuaProvider | None:
     if name == "gemini":
         from .gemini import GeminiProvider
         return GeminiProvider()
+    if name == "tzafon":
+        from .tzafon import TzafonProvider
+        return TzafonProvider()
+    if name == "yutori":
+        from .yutori import YutoriProvider
+        return YutoriProvider()
+    if name == "openagi":
+        from .openagi import OpenAGIProvider
+        return OpenAGIProvider()
     return None
 
 
@@ -82,7 +91,7 @@ def resolve_providers() -> list[CuaProvider]:
     if not providers:
         raise RuntimeError(
             "No CUA provider is configured. "
-            "Set CUA_PROVIDER to one of: anthropic, openai, gemini, "
+            "Set CUA_PROVIDER to one of: anthropic, openai, gemini, tzafon, yutori, openagi, "
             "and provide the matching API key."
         )
 

--- a/pkg/templates/python/cua/providers/openagi.py
+++ b/pkg/templates/python/cua/providers/openagi.py
@@ -1,0 +1,259 @@
+"""OpenAGI CUA provider adapter using the Lux computer-use models.
+
+Uses the oagi SDK's AsyncDefaultAgent with Kernel's Computer Controls API.
+Only available in Python (no TypeScript SDK exists).
+
+Note: pyautogui and mouseinfo must be mocked before importing oagi to prevent
+X11 connection errors in headless environments.
+
+@see https://agiopen.org
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import os
+import sys
+import time
+from types import ModuleType
+from importlib.machinery import ModuleSpec
+
+# Mock pyautogui and mouseinfo before importing oagi — they require X11
+# but we use Kernel's Computer Controls API instead.
+if "mouseinfo" not in sys.modules:
+    _mock_mouseinfo = ModuleType("mouseinfo")
+    _mock_mouseinfo.__spec__ = ModuleSpec("mouseinfo", None)
+    sys.modules["mouseinfo"] = _mock_mouseinfo
+
+if "pyautogui" not in sys.modules:
+    _mock_pyautogui = ModuleType("pyautogui")
+    _mock_pyautogui.__spec__ = ModuleSpec("pyautogui", None)
+    sys.modules["pyautogui"] = _mock_pyautogui
+
+from oagi import AsyncDefaultAgent
+from oagi.types.models.action import (
+    Action,
+    ActionType,
+    parse_coords,
+    parse_drag_coords,
+    parse_scroll,
+)
+from PIL import Image as PILImage
+
+from . import CuaProvider, TaskOptions, TaskResult
+
+DEFAULT_MODEL = "lux-actor-1"
+
+# Key mappings from pyautogui/Lux format to xdotool format
+XDOTOOL_KEY_MAP = {
+    "enter": "Return", "return": "Return",
+    "escape": "Escape", "esc": "Escape",
+    "backspace": "BackSpace", "tab": "Tab", "space": "space",
+    "up": "Up", "down": "Down", "left": "Left", "right": "Right",
+    "pageup": "Page_Up", "page_up": "Page_Up", "pgup": "Page_Up",
+    "pagedown": "Page_Down", "page_down": "Page_Down", "pgdn": "Page_Down",
+    "home": "Home", "end": "End",
+    "insert": "Insert", "delete": "Delete", "del": "Delete",
+    "ctrl": "ctrl", "control": "ctrl",
+    "alt": "alt", "shift": "shift",
+    "super": "super", "win": "super", "command": "super", "cmd": "super", "meta": "super",
+    **{f"f{i}": f"F{i}" for i in range(1, 13)},
+}
+
+
+def _translate_key(key: str) -> str:
+    k = key.strip().lower()
+    if k in XDOTOOL_KEY_MAP:
+        return XDOTOOL_KEY_MAP[k]
+    if len(key) == 1:
+        return key
+    return key.capitalize()
+
+
+def _parse_hotkey(args_str: str) -> list[str]:
+    args_str = args_str.strip("()")
+    keys = [_translate_key(k.strip()) for k in args_str.split("+")]
+    if len(keys) > 1:
+        return ["+".join(keys)]
+    return keys
+
+
+class _KernelImage:
+    """Lightweight Image wrapper implementing the oagi Image protocol."""
+
+    def __init__(self, data: bytes, width: int | None = None, height: int | None = None):
+        self._data = data
+        self._width = width
+        self._height = height
+
+    def read(self) -> bytes:
+        return self._data
+
+    def resize(self, width: int, height: int) -> "_KernelImage":
+        img = PILImage.open(io.BytesIO(self._data))
+        resized = img.resize((width, height), PILImage.Resampling.LANCZOS)
+        buf = io.BytesIO()
+        if resized.mode == "RGBA":
+            rgb = PILImage.new("RGB", resized.size, (255, 255, 255))
+            rgb.paste(resized, mask=resized.split()[3])
+            resized = rgb
+        resized.save(buf, format="JPEG", quality=85)
+        return _KernelImage(buf.getvalue(), width, height)
+
+
+class OpenAGIProvider:
+    name = "openagi"
+
+    def __init__(self) -> None:
+        self._api_key = os.environ.get("OAGI_API_KEY", "")
+
+    def is_configured(self) -> bool:
+        return len(self._api_key) > 0
+
+    async def run_task(self, options: TaskOptions) -> TaskResult:
+        model = options.model or DEFAULT_MODEL
+        computer = options.kernel.browsers.computer
+        width = options.viewport_width
+        height = options.viewport_height
+
+        # Set base URL for oagi
+        os.environ.setdefault("OAGI_BASE_URL", "https://api.agiopen.org")
+
+        # Screenshot provider (implements AsyncImageProvider protocol)
+        last_image: _KernelImage | None = None
+
+        async def take_screenshot() -> _KernelImage:
+            nonlocal last_image
+            res = computer.capture_screenshot(options.session_id)
+            raw = res.read()
+            img = _KernelImage(raw)
+            img = img.resize(1260, 700)
+            last_image = img
+            return img
+
+        async def get_last_image() -> _KernelImage:
+            if last_image is None:
+                return await take_screenshot()
+            return last_image
+
+        # Action handler (implements AsyncActionHandler protocol)
+        def denormalize(x: int, y: int) -> tuple[int, int]:
+            sx = max(1, min(int(x * width / 1000), width - 1))
+            sy = max(1, min(int(y * height / 1000), height - 1))
+            return sx, sy
+
+        def execute_single_action(action: Action) -> None:
+            arg = action.argument.strip("()")
+
+            match action.type:
+                case ActionType.CLICK:
+                    coords = parse_coords(arg)
+                    if not coords:
+                        raise ValueError(f"Invalid coordinates: {arg}")
+                    x, y = denormalize(coords[0], coords[1])
+                    computer.click_mouse(options.session_id, x=x, y=y)
+
+                case ActionType.LEFT_DOUBLE:
+                    coords = parse_coords(arg)
+                    if not coords:
+                        raise ValueError(f"Invalid coordinates: {arg}")
+                    x, y = denormalize(coords[0], coords[1])
+                    computer.click_mouse(options.session_id, x=x, y=y, num_clicks=2)
+
+                case ActionType.LEFT_TRIPLE:
+                    coords = parse_coords(arg)
+                    if not coords:
+                        raise ValueError(f"Invalid coordinates: {arg}")
+                    x, y = denormalize(coords[0], coords[1])
+                    computer.click_mouse(options.session_id, x=x, y=y, num_clicks=3)
+
+                case ActionType.RIGHT_SINGLE:
+                    coords = parse_coords(arg)
+                    if not coords:
+                        raise ValueError(f"Invalid coordinates: {arg}")
+                    x, y = denormalize(coords[0], coords[1])
+                    computer.click_mouse(options.session_id, x=x, y=y, button="right")
+
+                case ActionType.DRAG:
+                    coords = parse_drag_coords(arg)
+                    if not coords:
+                        raise ValueError(f"Invalid drag coordinates: {arg}")
+                    x1, y1 = denormalize(coords[0], coords[1])
+                    x2, y2 = denormalize(coords[2], coords[3])
+                    computer.drag_mouse(
+                        options.session_id, path=[[x1, y1], [x2, y2]], button="left",
+                    )
+
+                case ActionType.HOTKEY:
+                    keys = _parse_hotkey(arg)
+                    computer.press_key(options.session_id, keys=keys)
+
+                case ActionType.TYPE:
+                    text = arg.strip("\"'")
+                    press_enter = text.endswith("\n") or text.endswith("\\n")
+                    if press_enter:
+                        text = text.rstrip("\n").rstrip("\\n")
+                    computer.type_text(options.session_id, text=text, delay=50)
+                    if press_enter:
+                        computer.press_key(options.session_id, keys=["Return"])
+
+                case ActionType.SCROLL:
+                    result = parse_scroll(arg)
+                    if not result:
+                        raise ValueError(f"Invalid scroll format: {arg}")
+                    x, y = denormalize(result[0], result[1])
+                    direction = result[2]
+                    dx = dy = 0
+                    if direction == "up": dy = -1
+                    elif direction == "down": dy = 1
+                    elif direction == "left": dx = -1
+                    elif direction == "right": dx = 1
+                    computer.scroll(
+                        options.session_id, x=x, y=y, delta_x=dx, delta_y=dy,
+                    )
+
+                case ActionType.FINISH:
+                    pass
+
+                case ActionType.WAIT:
+                    time.sleep(1.0)
+
+                case ActionType.CALL_USER:
+                    pass
+
+                case _:
+                    print(f"Unknown action type: {action.type}")
+
+        def execute_action(action: Action) -> None:
+            count = action.count or 1
+            for _ in range(count):
+                execute_single_action(action)
+                if count > 1:
+                    time.sleep(0.1)
+
+        async def handle_actions(actions: list[Action]) -> None:
+            for action in actions:
+                await asyncio.get_event_loop().run_in_executor(
+                    None, execute_action, action,
+                )
+                await asyncio.sleep(0.1)
+
+        # Run the agent
+        agent = AsyncDefaultAgent(
+            api_key=self._api_key,
+            max_steps=20,
+            model=model,
+        )
+
+        success = await agent.execute(
+            instruction=options.query,
+            action_handler=handle_actions,
+            image_provider=take_screenshot,
+        )
+
+        # The oagi agent doesn't return text results directly — report success/failure
+        return TaskResult(
+            result=f"Task completed. Success: {success}",
+            provider=self.name,
+        )

--- a/pkg/templates/python/cua/providers/tzafon.py
+++ b/pkg/templates/python/cua/providers/tzafon.py
@@ -1,0 +1,311 @@
+"""Tzafon CUA provider adapter using the Lightcone Responses API.
+
+Uses function tools (click, type, key, scroll, drag, done) with a
+normalised 0-999 coordinate grid.
+
+@see https://docs.lightcone.ai
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+from typing import Any
+
+from tzafon import Lightcone
+
+from . import CuaProvider, TaskOptions, TaskResult
+
+DEFAULT_MODEL = "tzafon.northstar-cua-fast"
+
+INSTRUCTIONS = (
+    "Use a mouse and keyboard to interact with a Chromium browser and take screenshots.\n"
+    "* Chromium is already open on a Kernel cloud browser. If a startup wizard appears, ignore it.\n"
+    "* The screen's coordinate space is a 0-999 grid.\n"
+    "* To navigate to a URL, use point_and_type on the address bar, or key('ctrl+l') to focus it first.\n"
+    "* Some pages may take time to load. Wait and take successive screenshots to confirm the result.\n"
+    "* Whenever you click on an element, consult the screenshot to determine coordinates first.\n"
+    "* Click buttons, links, and icons in the center of the element, not on edges.\n"
+    "* If a click didn't work, try adjusting the coordinates slightly.\n"
+    "* For full-page scrolling, prefer key('PageDown') / key('PageUp') over the scroll tool.\n"
+    "* After each action, evaluate the screenshot to confirm it succeeded before moving on.\n"
+    "* When the task is complete, call done() with a summary of what you found or accomplished.\n"
+)
+
+TOOLS = [
+    {
+        "type": "function", "name": "click",
+        "description": "Single click at (x, y) in 0-999 grid.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "x": {"type": "integer", "description": "X in 0-999 grid"},
+                "y": {"type": "integer", "description": "Y in 0-999 grid"},
+                "button": {"type": "string", "enum": ["left", "right"]},
+            },
+            "required": ["x", "y"],
+        },
+    },
+    {
+        "type": "function", "name": "double_click",
+        "description": "Double click at (x, y) in 0-999 grid.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "x": {"type": "integer", "description": "X in 0-999 grid"},
+                "y": {"type": "integer", "description": "Y in 0-999 grid"},
+            },
+            "required": ["x", "y"],
+        },
+    },
+    {
+        "type": "function", "name": "point_and_type",
+        "description": "Click at position then type text. For input fields, search bars, address bars.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "x": {"type": "integer", "description": "X in 0-999 grid"},
+                "y": {"type": "integer", "description": "Y in 0-999 grid"},
+                "text": {"type": "string"},
+                "press_enter": {"type": "boolean", "description": "Press Enter after typing"},
+            },
+            "required": ["x", "y", "text"],
+        },
+    },
+    {
+        "type": "function", "name": "key",
+        "description": "Press key combo (e.g. 'Enter', 'ctrl+a', 'Tab').",
+        "parameters": {
+            "type": "object",
+            "properties": {"keys": {"type": "string"}},
+            "required": ["keys"],
+        },
+    },
+    {
+        "type": "function", "name": "scroll",
+        "description": "Scroll at (x, y) in 0-999 grid. Positive dy = down, negative = up.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "x": {"type": "integer", "description": "X in 0-999 grid"},
+                "y": {"type": "integer", "description": "Y in 0-999 grid"},
+                "dy": {"type": "integer", "description": "Scroll notches. 3=down, -3=up."},
+            },
+            "required": ["x", "y", "dy"],
+        },
+    },
+    {
+        "type": "function", "name": "drag",
+        "description": "Drag from (x1, y1) to (x2, y2) in 0-999 grid.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "x1": {"type": "integer", "description": "Start X in 0-999 grid"},
+                "y1": {"type": "integer", "description": "Start Y in 0-999 grid"},
+                "x2": {"type": "integer", "description": "End X in 0-999 grid"},
+                "y2": {"type": "integer", "description": "End Y in 0-999 grid"},
+            },
+            "required": ["x1", "y1", "x2", "y2"],
+        },
+    },
+    {
+        "type": "function", "name": "done",
+        "description": "Task complete. Report findings.",
+        "parameters": {
+            "type": "object",
+            "properties": {"result": {"type": "string"}},
+            "required": ["result"],
+        },
+    },
+]
+
+KEY_MAP: dict[str, str] = {
+    "return": "Return", "enter": "Return",
+    "space": "space", "tab": "Tab",
+    "backspace": "BackSpace", "delete": "Delete",
+    "escape": "Escape", "esc": "Escape", "insert": "Insert",
+    "up": "Up", "down": "Down", "left": "Left", "right": "Right",
+    "home": "Home", "end": "End",
+    "pageup": "Page_Up", "page_up": "Page_Up",
+    "pagedown": "Page_Down", "page_down": "Page_Down",
+    **{f"f{i}": f"F{i}" for i in range(1, 13)},
+}
+
+MODIFIER_MAP: dict[str, str] = {
+    "ctrl": "ctrl", "control": "ctrl",
+    "alt": "alt", "shift": "shift",
+    "meta": "super", "cmd": "super", "command": "super", "win": "super",
+}
+
+
+def _map_key(key_combo: str) -> str:
+    parts = key_combo.split("+") if "+" in key_combo else [key_combo]
+    mapped = []
+    for part in parts:
+        k = part.strip().lower()
+        mapped.append(MODIFIER_MAP.get(k) or KEY_MAP.get(k, part.strip()))
+    return "+".join(mapped)
+
+
+def _coord(val: Any) -> int:
+    if val is None:
+        return 0
+    s = str(val)
+    if "," in s:
+        s = s.split(",")[0].strip()
+    return int(float(s))
+
+
+class TzafonProvider:
+    name = "tzafon"
+
+    def __init__(self) -> None:
+        self._api_key = os.environ.get("TZAFON_API_KEY", "")
+
+    def is_configured(self) -> bool:
+        return len(self._api_key) > 0
+
+    async def run_task(self, options: TaskOptions) -> TaskResult:
+        model = options.model or DEFAULT_MODEL
+        tzafon = Lightcone(api_key=self._api_key)
+        computer = options.kernel.browsers.computer
+        width = options.viewport_width
+        height = options.viewport_height
+        max_steps = 50
+
+        def scale(x: Any, y: Any) -> tuple[int, int]:
+            cx, cy = _coord(x), _coord(y)
+            px = max(0, min(cx * (width - 1) // 999, width - 1))
+            py = max(0, min(cy * (height - 1) // 999, height - 1))
+            return px, py
+
+        def capture_screenshot() -> str:
+            res = computer.capture_screenshot(options.session_id)
+            b64 = base64.b64encode(res.read()).decode()
+            return f"data:image/png;base64,{b64}"
+
+        async def execute_function(name: str, args: dict) -> None:
+            if name == "click":
+                px, py = scale(args["x"], args["y"])
+                computer.click_mouse(
+                    options.session_id, x=px, y=py, button=args.get("button", "left"),
+                )
+            elif name == "double_click":
+                px, py = scale(args["x"], args["y"])
+                computer.click_mouse(options.session_id, x=px, y=py, num_clicks=2)
+            elif name == "point_and_type":
+                px, py = scale(args["x"], args["y"])
+                computer.click_mouse(options.session_id, x=px, y=py)
+                await asyncio.sleep(0.3)
+                computer.type_text(options.session_id, text=args["text"])
+                if args.get("press_enter"):
+                    await asyncio.sleep(0.1)
+                    computer.press_key(options.session_id, keys=["Return"])
+            elif name == "key":
+                computer.press_key(
+                    options.session_id, keys=[_map_key(args["keys"])],
+                )
+            elif name == "scroll":
+                px, py = scale(args.get("x", 500), args.get("y", 500))
+                dy = max(-10, min(10, int(args.get("dy", 3))))
+                computer.scroll(
+                    options.session_id, x=px, y=py, delta_x=0, delta_y=dy,
+                )
+            elif name == "drag":
+                px1, py1 = scale(args["x1"], args["y1"])
+                px2, py2 = scale(args["x2"], args["y2"])
+                computer.drag_mouse(
+                    options.session_id, path=[[px1, py1], [px2, py2]],
+                )
+            else:
+                raise ValueError(f"Unknown function: {name}")
+
+        def img(screenshot_url: str, text: str = "screenshot") -> dict:
+            return {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": text},
+                    {"type": "input_image", "image_url": screenshot_url, "detail": "auto"},
+                ],
+            }
+
+        screenshot_url = capture_screenshot()
+        items: list[Any] = [img(screenshot_url, text=f"{options.query}\n\nCurrent screenshot:")]
+        resp: Any = None
+
+        for step in range(max_steps):
+            # Prevent unbounded payload growth
+            if len(items) > 30:
+                items = items[:2] + items[-20:]
+
+            resp = tzafon.responses.create(
+                model=model, input=items, tools=TOOLS,
+                instructions=INSTRUCTIONS,
+                temperature=0, max_output_tokens=4096,
+            )
+
+            calls: list[tuple[str, str, dict]] = []
+            for item in resp.output or []:
+                if item.type == "message":
+                    for block in item.content or []:
+                        text = block.text or ""
+                        if text:
+                            items.append({"role": "assistant", "content": text})
+
+                elif item.type == "function_call":
+                    call_id = item.call_id
+                    fn_name = item.name
+                    raw_args = item.arguments or "{}"
+                    try:
+                        args = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
+                    except (json.JSONDecodeError, TypeError):
+                        args = {}
+                    calls.append((call_id, fn_name, args))
+                    items.append({
+                        "type": "function_call", "call_id": call_id, "name": fn_name,
+                        "arguments": raw_args if isinstance(raw_args, str) else json.dumps(raw_args),
+                    })
+
+            if not calls:
+                continue
+
+            for call_id, fn_name, args in calls:
+                if fn_name == "done":
+                    return TaskResult(result=args.get("result", ""), provider=self.name)
+
+                try:
+                    await execute_function(fn_name, args)
+                except Exception as e:
+                    items.append({"type": "function_call_output", "call_id": call_id, "output": f"Error: {e}"})
+                    continue
+
+                await asyncio.sleep(0.5)
+                screenshot_url = capture_screenshot()
+
+                # Replace old screenshots with placeholders
+                for it in items[:-1]:
+                    c = it.get("content") if isinstance(it, dict) else None
+                    if isinstance(c, list):
+                        has_img = any(isinstance(p, dict) and p.get("type") == "input_image" for p in c)
+                        if has_img:
+                            it["content"] = [
+                                p for p in c if not (isinstance(p, dict) and p.get("type") == "input_image")
+                            ] or "(old screenshot)"
+
+                items.append({"type": "function_call_output", "call_id": call_id, "output": "[screenshot]"})
+                items.append(img(screenshot_url))
+
+        messages: list[str] = []
+        if resp:
+            for item in resp.output or []:
+                if item.type == "message":
+                    for block in item.content or []:
+                        if block.text:
+                            messages.append(block.text)
+
+        return TaskResult(
+            result=" ".join(messages) if messages else "(max iterations reached)",
+            provider=self.name,
+        )

--- a/pkg/templates/python/cua/providers/yutori.py
+++ b/pkg/templates/python/cua/providers/yutori.py
@@ -1,0 +1,264 @@
+"""Yutori CUA provider adapter using the n1-latest model.
+
+Uses an OpenAI-compatible API with tool_calls. Coordinates are returned in
+1000x1000 space and scaled to viewport dimensions. Screenshots are converted
+to WebP for better compression.
+
+@see https://docs.yutori.com/reference/n1
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+from io import BytesIO
+
+from openai import OpenAI
+from PIL import Image
+
+from . import CuaProvider, TaskOptions, TaskResult
+
+DEFAULT_MODEL = "n1-latest"
+TYPING_DELAY_MS = 12
+SCREENSHOT_DELAY_S = 0.3
+ACTION_DELAY_S = 0.3
+
+KEY_MAP = {
+    "Enter": "Return", "Escape": "Escape", "Backspace": "BackSpace",
+    "Tab": "Tab", "Delete": "Delete",
+    "ArrowUp": "Up", "ArrowDown": "Down", "ArrowLeft": "Left", "ArrowRight": "Right",
+    "Home": "Home", "End": "End", "PageUp": "Page_Up", "PageDown": "Page_Down",
+    **{f"F{i}": f"F{i}" for i in range(1, 13)},
+}
+
+MODIFIER_MAP = {
+    "control": "ctrl", "ctrl": "ctrl", "alt": "alt", "shift": "shift",
+    "meta": "super", "command": "super", "cmd": "super",
+}
+
+
+def _map_key(key: str) -> str:
+    if "+" in key:
+        parts = key.split("+")
+        mapped = []
+        for part in parts:
+            trimmed = part.strip()
+            lower = trimmed.lower()
+            if lower in MODIFIER_MAP:
+                mapped.append(MODIFIER_MAP[lower])
+            else:
+                mapped.append(KEY_MAP.get(trimmed, trimmed))
+        return "+".join(mapped)
+    return KEY_MAP.get(key, key)
+
+
+class YutoriProvider:
+    name = "yutori"
+
+    def __init__(self) -> None:
+        self._api_key = os.environ.get("YUTORI_API_KEY", "")
+
+    def is_configured(self) -> bool:
+        return len(self._api_key) > 0
+
+    async def run_task(self, options: TaskOptions) -> TaskResult:
+        model = options.model or DEFAULT_MODEL
+        client = OpenAI(api_key=self._api_key, base_url="https://api.yutori.com/v1")
+        computer = options.kernel.browsers.computer
+        width = options.viewport_width
+        height = options.viewport_height
+        max_iterations = 50
+
+        def capture_screenshot() -> str:
+            res = computer.capture_screenshot(options.session_id)
+            png_bytes = res.read()
+            img = Image.open(BytesIO(png_bytes))
+            webp_buf = BytesIO()
+            img.save(webp_buf, "WEBP", quality=80)
+            return base64.b64encode(webp_buf.getvalue()).decode("utf-8")
+
+        def scale_coords(coords: list) -> list:
+            return [
+                round((coords[0] / 1000) * width),
+                round((coords[1] / 1000) * height),
+            ]
+
+        def get_coords(coords: list | None) -> dict:
+            if coords is None or len(coords) != 2:
+                return {"x": width // 2, "y": height // 2}
+            return {"x": int(coords[0]), "y": int(coords[1])}
+
+        async def execute_action(action: dict) -> str | None:
+            action_type = action.get("action_type")
+
+            if action_type in ("left_click", "double_click", "triple_click", "right_click"):
+                c = get_coords(action.get("coordinates"))
+                button = "right" if action_type == "right_click" else "left"
+                num = 2 if action_type == "double_click" else 3 if action_type == "triple_click" else 1
+                computer.click_mouse(
+                    options.session_id, x=c["x"], y=c["y"],
+                    button=button, click_type="click", num_clicks=num,
+                )
+                await asyncio.sleep(SCREENSHOT_DELAY_S)
+                return capture_screenshot()
+
+            elif action_type == "scroll":
+                c = get_coords(action.get("coordinates"))
+                notches = max(action.get("amount", 3), 1)
+                direction = action.get("direction", "down")
+                dx = dy = 0
+                if direction == "up": dy = -notches
+                elif direction == "down": dy = notches
+                elif direction == "left": dx = -notches
+                elif direction == "right": dx = notches
+                computer.scroll(
+                    options.session_id, x=c["x"], y=c["y"], delta_x=dx, delta_y=dy,
+                )
+                await asyncio.sleep(SCREENSHOT_DELAY_S)
+                return capture_screenshot()
+
+            elif action_type == "type":
+                text = action.get("text")
+                if not text:
+                    raise ValueError("text is required for type action")
+                if action.get("clear_before_typing"):
+                    computer.press_key(options.session_id, keys=["ctrl+a"])
+                    await asyncio.sleep(0.1)
+                    computer.press_key(options.session_id, keys=["BackSpace"])
+                    await asyncio.sleep(0.1)
+                computer.type_text(options.session_id, text=text, delay=TYPING_DELAY_MS)
+                if action.get("press_enter_after"):
+                    await asyncio.sleep(0.1)
+                    computer.press_key(options.session_id, keys=["Return"])
+                await asyncio.sleep(SCREENSHOT_DELAY_S)
+                return capture_screenshot()
+
+            elif action_type == "key_press":
+                key_comb = action.get("key_comb")
+                if not key_comb:
+                    raise ValueError("key_comb is required for key_press action")
+                computer.press_key(options.session_id, keys=[_map_key(key_comb)])
+                await asyncio.sleep(SCREENSHOT_DELAY_S)
+                return capture_screenshot()
+
+            elif action_type == "hover":
+                c = get_coords(action.get("coordinates"))
+                computer.move_mouse(options.session_id, x=c["x"], y=c["y"])
+                await asyncio.sleep(SCREENSHOT_DELAY_S)
+                return capture_screenshot()
+
+            elif action_type == "drag":
+                start = get_coords(action.get("start_coordinates"))
+                end = get_coords(action.get("coordinates"))
+                computer.drag_mouse(
+                    options.session_id,
+                    path=[[start["x"], start["y"]], [end["x"], end["y"]]],
+                    button="left",
+                )
+                await asyncio.sleep(SCREENSHOT_DELAY_S)
+                return capture_screenshot()
+
+            elif action_type == "wait":
+                await asyncio.sleep(2)
+                return capture_screenshot()
+
+            elif action_type == "refresh":
+                computer.press_key(options.session_id, keys=["F5"])
+                await asyncio.sleep(2)
+                return capture_screenshot()
+
+            elif action_type == "go_back":
+                computer.press_key(options.session_id, keys=["alt+Left"])
+                await asyncio.sleep(1.5)
+                return capture_screenshot()
+
+            elif action_type == "goto_url":
+                url = action.get("url")
+                if not url:
+                    raise ValueError("url is required for goto_url action")
+                computer.press_key(options.session_id, keys=["ctrl+l"])
+                await asyncio.sleep(ACTION_DELAY_S)
+                computer.press_key(options.session_id, keys=["ctrl+a"])
+                await asyncio.sleep(0.1)
+                computer.type_text(options.session_id, text=url, delay=TYPING_DELAY_MS)
+                await asyncio.sleep(ACTION_DELAY_S)
+                computer.press_key(options.session_id, keys=["Return"])
+                await asyncio.sleep(2)
+                return capture_screenshot()
+
+            else:
+                raise ValueError(f"Unknown action type: {action_type}")
+
+        # Take initial screenshot
+        initial_screenshot = capture_screenshot()
+        conversation: list[dict] = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": options.query},
+                    {"type": "image_url", "image_url": {"url": f"data:image/webp;base64,{initial_screenshot}"}},
+                ],
+            }
+        ]
+
+        for _iteration in range(max_iterations):
+            response = client.chat.completions.create(
+                model=model,
+                messages=conversation,
+                max_completion_tokens=4096,
+                temperature=0.3,
+            )
+
+            choice = response.choices[0]
+            if not choice.message:
+                raise ValueError("No response from model")
+
+            conversation.append(choice.message.model_dump(exclude_none=True))
+
+            tool_calls = choice.message.tool_calls
+            if not tool_calls:
+                return TaskResult(
+                    result=choice.message.content or "(no response)",
+                    provider=self.name,
+                )
+
+            for tc in tool_calls:
+                try:
+                    args = json.loads(tc.function.arguments)
+                except json.JSONDecodeError:
+                    conversation.append({
+                        "role": "tool", "tool_call_id": tc.id,
+                        "content": "Error: failed to parse arguments",
+                    })
+                    continue
+
+                action = {"action_type": tc.function.name, **args}
+
+                # Scale coordinates from 1000x1000 to viewport
+                if action.get("coordinates"):
+                    action["coordinates"] = scale_coords(action["coordinates"])
+                if action.get("start_coordinates"):
+                    action["start_coordinates"] = scale_coords(action["start_coordinates"])
+
+                try:
+                    screenshot = await execute_action(action)
+                    if screenshot:
+                        conversation.append({
+                            "role": "tool", "tool_call_id": tc.id,
+                            "content": [
+                                {"type": "image_url", "image_url": {"url": f"data:image/webp;base64,{screenshot}"}},
+                            ],
+                        })
+                    else:
+                        conversation.append({
+                            "role": "tool", "tool_call_id": tc.id, "content": "OK",
+                        })
+                except Exception as e:
+                    conversation.append({
+                        "role": "tool", "tool_call_id": tc.id,
+                        "content": f"Action failed: {e}",
+                    })
+
+        return TaskResult(result="(max iterations reached)", provider=self.name)

--- a/pkg/templates/python/cua/pyproject.toml
+++ b/pkg/templates/python/cua/pyproject.toml
@@ -9,6 +9,9 @@ dependencies = [
     "google-genai>=1.71.0",
     "httpx>=0.28.1",
     "kernel>=0.47.0",
+    "oagi>=0.1.0",
     "openai>=2.30.0",
+    "Pillow>=10.0.0",
     "python-dotenv>=1.2.2",
+    "tzafon>=2.31.0",
 ]

--- a/pkg/templates/typescript/cua/.env.example
+++ b/pkg/templates/typescript/cua/.env.example
@@ -1,7 +1,7 @@
 # Copy this file to .env and fill in your API keys.
 # Only the key for your chosen provider is required.
 
-# Primary provider: "anthropic", "openai", or "gemini"
+# Primary provider: "anthropic", "openai", "gemini", "tzafon", or "yutori"
 CUA_PROVIDER=anthropic
 
 # Comma-separated fallback order (optional).
@@ -12,6 +12,8 @@ CUA_PROVIDER=anthropic
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
 OPENAI_API_KEY=your_openai_api_key_here
 GOOGLE_API_KEY=your_google_api_key_here
+TZAFON_API_KEY=your_tzafon_api_key_here
+YUTORI_API_KEY=your_yutori_api_key_here
 
 # Browser config (proxy, profile, extensions, timeout) is set per-request
 # via the payload "browser" field, not here. Example:

--- a/pkg/templates/typescript/cua/README.md
+++ b/pkg/templates/typescript/cua/README.md
@@ -1,6 +1,6 @@
 # Unified CUA Template
 
-A multi-provider Computer Use Agent (CUA) template for [Kernel](https://kernel.sh). Supports **Anthropic**, **OpenAI**, and **Google Gemini** as interchangeable backends with automatic fallback.
+A multi-provider Computer Use Agent (CUA) template for [Kernel](https://kernel.sh). Supports **Anthropic**, **OpenAI**, **Google Gemini**, **Tzafon**, and **Yutori** as interchangeable backends with automatic fallback.
 
 ## Quick start
 
@@ -25,6 +25,8 @@ Set `CUA_PROVIDER` to your preferred provider and add the matching API key:
 | `anthropic` | `ANTHROPIC_API_KEY`  | `claude-sonnet-4-6`                        |
 | `openai`    | `OPENAI_API_KEY`     | `gpt-5.4`                                 |
 | `gemini`    | `GOOGLE_API_KEY`     | `gemini-2.5-computer-use-preview-10-2025`  |
+| `tzafon`    | `TZAFON_API_KEY`     | `tzafon.northstar-cua-fast`                |
+| `yutori`    | `YUTORI_API_KEY`     | `n1-latest`                                |
 
 ### 3. Deploy to Kernel
 
@@ -69,6 +71,8 @@ providers/
   anthropic.ts        — Anthropic Claude adapter
   openai.ts           — OpenAI GPT adapter
   gemini.ts           — Google Gemini adapter
+  tzafon.ts           — Tzafon Northstar adapter
+  yutori.ts           — Yutori n1 adapter
 ```
 
 ## Customization
@@ -83,3 +87,5 @@ To add a new provider, create a new file that implements the `CuaProvider` inter
 - [Anthropic Computer Use](https://docs.anthropic.com/en/docs/agents-and-tools/computer-use)
 - [OpenAI Computer Use](https://platform.openai.com/docs/guides/computer-use)
 - [Google Gemini Computer Use](https://ai.google.dev/gemini-api/docs/computer-use)
+- [Tzafon Lightcone](https://docs.lightcone.ai)
+- [Yutori n1](https://docs.yutori.com/reference/n1)

--- a/pkg/templates/typescript/cua/package.json
+++ b/pkg/templates/typescript/cua/package.json
@@ -7,7 +7,9 @@
     "@anthropic-ai/sdk": "^0.86.1",
     "@google/genai": "^1.49.0",
     "@onkernel/sdk": "^0.47.0",
-    "openai": "^6.33.0"
+    "@tzafon/lightcone": "^0.7.0",
+    "openai": "^6.33.0",
+    "sharp": "^0.33.0"
   },
   "devDependencies": {
     "@types/node": "^22.15.17",

--- a/pkg/templates/typescript/cua/providers/index.ts
+++ b/pkg/templates/typescript/cua/providers/index.ts
@@ -12,6 +12,8 @@ import type { Kernel } from '@onkernel/sdk';
 import { AnthropicProvider } from './anthropic';
 import { OpenAIProvider } from './openai';
 import { GeminiProvider } from './gemini';
+import { TzafonProvider } from './tzafon';
+import { YutoriProvider } from './yutori';
 
 // Shared interface every provider adapter must implement.
 export interface TaskOptions {
@@ -34,12 +36,14 @@ export interface CuaProvider {
   runTask(options: TaskOptions): Promise<TaskResult>;
 }
 
-export type ProviderName = 'anthropic' | 'openai' | 'gemini';
+export type ProviderName = 'anthropic' | 'openai' | 'gemini' | 'tzafon' | 'yutori';
 
 const PROVIDERS: Record<ProviderName, () => CuaProvider> = {
   anthropic: () => new AnthropicProvider(),
   openai: () => new OpenAIProvider(),
   gemini: () => new GeminiProvider(),
+  tzafon: () => new TzafonProvider(),
+  yutori: () => new YutoriProvider(),
 };
 
 /**

--- a/pkg/templates/typescript/cua/providers/tzafon.ts
+++ b/pkg/templates/typescript/cua/providers/tzafon.ts
@@ -1,0 +1,337 @@
+/**
+ * Tzafon CUA provider adapter.
+ *
+ * Uses the Tzafon Lightcone Responses API with function tools (click, type,
+ * key, scroll, drag, done). Coordinates arrive in a normalised 0-999 grid.
+ *
+ * @see https://docs.lightcone.ai
+ */
+
+import Lightcone from '@tzafon/lightcone';
+import type { CuaProvider, TaskOptions, TaskResult } from './index';
+
+const DEFAULT_MODEL = 'tzafon.northstar-cua-fast';
+
+const INSTRUCTIONS = [
+  'Use a mouse and keyboard to interact with a Chromium browser and take screenshots.',
+  '* Chromium is already open on a Kernel cloud browser. If a startup wizard appears, ignore it.',
+  "* The screen's coordinate space is a 0-999 grid.",
+  "* To navigate to a URL, use point_and_type on the address bar, or key('ctrl+l') to focus it first.",
+  '* Some pages may take time to load. Wait and take successive screenshots to confirm the result.',
+  '* Whenever you click on an element, consult the screenshot to determine coordinates first.',
+  '* Click buttons, links, and icons in the center of the element, not on edges.',
+  "* If a click didn't work, try adjusting the coordinates slightly.",
+  "* For full-page scrolling, prefer key('PageDown') / key('PageUp') over the scroll tool.",
+  '* After each action, evaluate the screenshot to confirm it succeeded before moving on.',
+  '* When the task is complete, call done() with a summary of what you found or accomplished.',
+].join('\n');
+
+interface FunctionTool {
+  type: 'function';
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+}
+
+const TOOLS: FunctionTool[] = [
+  {
+    type: 'function', name: 'click',
+    description: 'Single click at (x, y) in 0-999 grid.',
+    parameters: {
+      type: 'object',
+      properties: {
+        x: { type: 'integer', description: 'X in 0-999 grid' },
+        y: { type: 'integer', description: 'Y in 0-999 grid' },
+        button: { type: 'string', enum: ['left', 'right'] },
+      },
+      required: ['x', 'y'],
+    },
+  },
+  {
+    type: 'function', name: 'double_click',
+    description: 'Double click at (x, y) in 0-999 grid.',
+    parameters: {
+      type: 'object',
+      properties: {
+        x: { type: 'integer', description: 'X in 0-999 grid' },
+        y: { type: 'integer', description: 'Y in 0-999 grid' },
+      },
+      required: ['x', 'y'],
+    },
+  },
+  {
+    type: 'function', name: 'point_and_type',
+    description: 'Click at position then type text. For input fields, search bars, address bars.',
+    parameters: {
+      type: 'object',
+      properties: {
+        x: { type: 'integer', description: 'X in 0-999 grid' },
+        y: { type: 'integer', description: 'Y in 0-999 grid' },
+        text: { type: 'string' },
+        press_enter: { type: 'boolean', description: 'Press Enter after typing' },
+      },
+      required: ['x', 'y', 'text'],
+    },
+  },
+  {
+    type: 'function', name: 'key',
+    description: "Press key combo (e.g. 'Enter', 'ctrl+a', 'Tab').",
+    parameters: {
+      type: 'object',
+      properties: { keys: { type: 'string' } },
+      required: ['keys'],
+    },
+  },
+  {
+    type: 'function', name: 'scroll',
+    description: 'Scroll at (x, y) in 0-999 grid. Positive dy = down, negative = up.',
+    parameters: {
+      type: 'object',
+      properties: {
+        x: { type: 'integer', description: 'X in 0-999 grid' },
+        y: { type: 'integer', description: 'Y in 0-999 grid' },
+        dy: { type: 'integer', description: 'Scroll notches. 3=down, -3=up.' },
+      },
+      required: ['x', 'y', 'dy'],
+    },
+  },
+  {
+    type: 'function', name: 'drag',
+    description: 'Drag from (x1, y1) to (x2, y2) in 0-999 grid.',
+    parameters: {
+      type: 'object',
+      properties: {
+        x1: { type: 'integer', description: 'Start X in 0-999 grid' },
+        y1: { type: 'integer', description: 'Start Y in 0-999 grid' },
+        x2: { type: 'integer', description: 'End X in 0-999 grid' },
+        y2: { type: 'integer', description: 'End Y in 0-999 grid' },
+      },
+      required: ['x1', 'y1', 'x2', 'y2'],
+    },
+  },
+  {
+    type: 'function', name: 'done',
+    description: 'Task complete. Report findings.',
+    parameters: {
+      type: 'object',
+      properties: { result: { type: 'string' } },
+      required: ['result'],
+    },
+  },
+];
+
+const KEY_MAP: Record<string, string> = {
+  return: 'Return', enter: 'Return',
+  space: 'space', tab: 'Tab',
+  backspace: 'BackSpace', delete: 'Delete',
+  escape: 'Escape', esc: 'Escape', insert: 'Insert',
+  up: 'Up', down: 'Down', left: 'Left', right: 'Right',
+  home: 'Home', end: 'End',
+  pageup: 'Page_Up', page_up: 'Page_Up',
+  pagedown: 'Page_Down', page_down: 'Page_Down',
+  ...Object.fromEntries(Array.from({ length: 12 }, (_, i) => [`f${i + 1}`, `F${i + 1}`])),
+};
+
+const MODIFIER_MAP: Record<string, string> = {
+  ctrl: 'ctrl', control: 'ctrl',
+  alt: 'alt', shift: 'shift',
+  meta: 'super', cmd: 'super', command: 'super', win: 'super',
+};
+
+function mapKey(keyCombo: string): string {
+  const parts = keyCombo.includes('+') ? keyCombo.split('+') : [keyCombo];
+  return parts
+    .map((p) => {
+      const k = p.trim().toLowerCase();
+      return MODIFIER_MAP[k] ?? KEY_MAP[k] ?? p.trim();
+    })
+    .join('+');
+}
+
+/** Parse a coordinate value. Handles the model's occasional '470,77' format. */
+function coord(val: unknown): number {
+  if (val == null) return 0;
+  let s = String(val);
+  if (s.includes(',')) s = s.split(',')[0].trim();
+  return Math.trunc(Number(s));
+}
+
+function get(obj: any, key: string, fallback?: any): any {
+  if (obj && typeof obj === 'object' && key in obj) return obj[key];
+  return fallback;
+}
+
+export class TzafonProvider implements CuaProvider {
+  readonly name = 'tzafon';
+  private apiKey: string;
+
+  constructor() {
+    this.apiKey = process.env.TZAFON_API_KEY ?? '';
+  }
+
+  isConfigured(): boolean {
+    return this.apiKey.length > 0;
+  }
+
+  async runTask(options: TaskOptions): Promise<TaskResult> {
+    const { query, kernel, sessionId, viewportWidth = 1280, viewportHeight = 800 } = options;
+    const model = options.model || DEFAULT_MODEL;
+    const tzafon = new Lightcone({ apiKey: this.apiKey });
+    const computer = kernel.browsers.computer;
+    const maxSteps = 50;
+
+    const captureScreenshot = async (): Promise<string> => {
+      const res = await computer.captureScreenshot(sessionId);
+      const buf = Buffer.from(await res.arrayBuffer());
+      return `data:image/png;base64,${buf.toString('base64')}`;
+    };
+
+    const scale = (x: unknown, y: unknown): [number, number] => {
+      const cx = coord(x);
+      const cy = coord(y);
+      const px = Math.max(0, Math.min(Math.trunc(cx * (viewportWidth - 1) / 999), viewportWidth - 1));
+      const py = Math.max(0, Math.min(Math.trunc(cy * (viewportHeight - 1) / 999), viewportHeight - 1));
+      return [px, py];
+    };
+
+    const executeFunction = async (name: string, args: Record<string, any>): Promise<void> => {
+      switch (name) {
+        case 'click': {
+          const [px, py] = scale(args.x, args.y);
+          await computer.clickMouse(sessionId, { x: px, y: py, button: args.button ?? 'left' });
+          break;
+        }
+        case 'double_click': {
+          const [px, py] = scale(args.x, args.y);
+          await computer.clickMouse(sessionId, { x: px, y: py, num_clicks: 2 });
+          break;
+        }
+        case 'point_and_type': {
+          const [px, py] = scale(args.x, args.y);
+          await computer.clickMouse(sessionId, { x: px, y: py });
+          await new Promise(r => setTimeout(r, 300));
+          await computer.typeText(sessionId, { text: args.text });
+          if (args.press_enter) {
+            await new Promise(r => setTimeout(r, 100));
+            await computer.pressKey(sessionId, { keys: ['Return'] });
+          }
+          break;
+        }
+        case 'key': {
+          await computer.pressKey(sessionId, { keys: [mapKey(args.keys)] });
+          break;
+        }
+        case 'scroll': {
+          const [px, py] = scale(args.x ?? 500, args.y ?? 500);
+          const dy = Math.max(-10, Math.min(10, args.dy ?? 3));
+          await computer.scroll(sessionId, { x: px, y: py, delta_x: 0, delta_y: dy });
+          break;
+        }
+        case 'drag': {
+          const [px1, py1] = scale(args.x1, args.y1);
+          const [px2, py2] = scale(args.x2, args.y2);
+          await computer.dragMouse(sessionId, { path: [[px1, py1], [px2, py2]] });
+          break;
+        }
+        default:
+          throw new Error(`Unknown function: ${name}`);
+      }
+    };
+
+    const img = (screenshotUrl: string, text = 'screenshot') => ({
+      role: 'user',
+      content: [
+        { type: 'input_text', text },
+        { type: 'input_image', image_url: screenshotUrl, detail: 'auto' },
+      ],
+    });
+
+    let screenshotUrl = await captureScreenshot();
+    const items: any[] = [img(screenshotUrl, `${query}\n\nCurrent screenshot:`)];
+    let resp: any;
+
+    for (let step = 0; step < maxSteps; step++) {
+      // Prevent unbounded payload growth
+      if (items.length > 30) {
+        items.splice(2, items.length - 22);
+      }
+
+      resp = await tzafon.responses.create({
+        model,
+        input: items,
+        tools: TOOLS,
+        instructions: INSTRUCTIONS,
+        temperature: 0,
+        max_output_tokens: 4096,
+      });
+
+      const calls: Array<{ callId: string; name: string; args: Record<string, any> }> = [];
+
+      for (const item of get(resp, 'output') ?? []) {
+        const itemType = get(item, 'type');
+
+        if (itemType === 'message') {
+          for (const block of get(item, 'content') ?? []) {
+            const text = get(block, 'text', '');
+            if (text) {
+              items.push({ role: 'assistant', content: text });
+            }
+          }
+        } else if (itemType === 'function_call') {
+          const callId = get(item, 'call_id');
+          const fnName = get(item, 'name');
+          const rawArgs = get(item, 'arguments', '{}');
+          let args: Record<string, any>;
+          try {
+            args = typeof rawArgs === 'string' ? JSON.parse(rawArgs) : rawArgs;
+          } catch {
+            args = {};
+          }
+          calls.push({ callId, name: fnName, args });
+          items.push({
+            type: 'function_call', call_id: callId, name: fnName,
+            arguments: typeof rawArgs === 'string' ? rawArgs : JSON.stringify(rawArgs),
+          });
+        }
+      }
+
+      if (calls.length === 0) continue;
+
+      for (const { callId, name, args } of calls) {
+        if (name === 'done') {
+          return { result: args.result ?? '', provider: this.name };
+        }
+
+        try {
+          await executeFunction(name, args);
+        } catch (e: any) {
+          items.push({ type: 'function_call_output', call_id: callId, output: `Error: ${e.message}` });
+          continue;
+        }
+
+        await new Promise(r => setTimeout(r, 500));
+        screenshotUrl = await captureScreenshot();
+
+        // Replace old screenshots with placeholders
+        for (const it of items.slice(0, -1)) {
+          const c = it?.content;
+          if (Array.isArray(c) && c.some((p: any) => p?.type === 'input_image')) {
+            it.content = c.filter((p: any) => p?.type !== 'input_image');
+            if (it.content.length === 0) it.content = '(old screenshot)';
+          }
+        }
+
+        items.push({ type: 'function_call_output', call_id: callId, output: '[screenshot]' });
+        items.push(img(screenshotUrl));
+      }
+    }
+
+    // Extract any final text from the last response
+    const messages = (get(resp, 'output') ?? [])
+      .filter((o: any) => get(o, 'type') === 'message')
+      .flatMap((o: any) => (get(o, 'content') ?? []).map((c: any) => get(c, 'text')))
+      .filter(Boolean);
+
+    return { result: messages.join(' ') || '(max iterations reached)', provider: this.name };
+  }
+}

--- a/pkg/templates/typescript/cua/providers/yutori.ts
+++ b/pkg/templates/typescript/cua/providers/yutori.ts
@@ -1,0 +1,271 @@
+/**
+ * Yutori CUA provider adapter.
+ *
+ * Uses Yutori's n1-latest model via an OpenAI-compatible API with tool_calls.
+ * Coordinates are returned in 1000x1000 space and scaled to viewport dimensions.
+ * Screenshots are converted to WebP for better compression.
+ *
+ * @see https://docs.yutori.com/reference/n1
+ */
+
+import OpenAI from 'openai';
+import sharp from 'sharp';
+import type { CuaProvider, TaskOptions, TaskResult } from './index';
+
+const DEFAULT_MODEL = 'n1-latest';
+const TYPING_DELAY_MS = 12;
+const SCREENSHOT_DELAY_MS = 300;
+const ACTION_DELAY_MS = 300;
+
+const KEY_MAP: Record<string, string> = {
+  'Enter': 'Return', 'Escape': 'Escape', 'Backspace': 'BackSpace',
+  'Tab': 'Tab', 'Delete': 'Delete',
+  'ArrowUp': 'Up', 'ArrowDown': 'Down', 'ArrowLeft': 'Left', 'ArrowRight': 'Right',
+  'Home': 'Home', 'End': 'End', 'PageUp': 'Page_Up', 'PageDown': 'Page_Down',
+  ...Object.fromEntries(Array.from({ length: 12 }, (_, i) => [`F${i + 1}`, `F${i + 1}`])),
+};
+
+const MODIFIER_MAP: Record<string, string> = {
+  control: 'ctrl', ctrl: 'ctrl', alt: 'alt', shift: 'shift',
+  meta: 'super', command: 'super', cmd: 'super',
+};
+
+function mapKey(key: string): string {
+  if (key.includes('+')) {
+    return key.split('+').map(part => {
+      const trimmed = part.trim();
+      const lower = trimmed.toLowerCase();
+      return MODIFIER_MAP[lower] ?? KEY_MAP[trimmed] ?? trimmed;
+    }).join('+');
+  }
+  return KEY_MAP[key] ?? key;
+}
+
+type N1ActionType =
+  | 'left_click' | 'double_click' | 'triple_click' | 'right_click'
+  | 'scroll' | 'type' | 'key_press' | 'hover' | 'drag'
+  | 'wait' | 'refresh' | 'go_back' | 'goto_url';
+
+interface N1Action {
+  action_type: N1ActionType;
+  coordinates?: [number, number];
+  start_coordinates?: [number, number];
+  direction?: 'up' | 'down' | 'left' | 'right';
+  amount?: number;
+  text?: string;
+  press_enter_after?: boolean;
+  clear_before_typing?: boolean;
+  key_comb?: string;
+  url?: string;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export class YutoriProvider implements CuaProvider {
+  readonly name = 'yutori';
+  private apiKey: string;
+
+  constructor() {
+    this.apiKey = process.env.YUTORI_API_KEY ?? '';
+  }
+
+  isConfigured(): boolean {
+    return this.apiKey.length > 0;
+  }
+
+  async runTask(options: TaskOptions): Promise<TaskResult> {
+    const { query, kernel, sessionId, viewportWidth = 1280, viewportHeight = 800 } = options;
+    const model = options.model || DEFAULT_MODEL;
+    const client = new OpenAI({ apiKey: this.apiKey, baseURL: 'https://api.yutori.com/v1' });
+    const computer = kernel.browsers.computer;
+    const maxIterations = 50;
+
+    const captureScreenshot = async (): Promise<string> => {
+      const res = await computer.captureScreenshot(sessionId);
+      const buf = Buffer.from(await res.arrayBuffer());
+      const webpBuf = await sharp(buf).webp({ quality: 80 }).toBuffer();
+      return webpBuf.toString('base64');
+    };
+
+    const scaleCoords = (coords: [number, number]): [number, number] => [
+      Math.round((coords[0] / 1000) * viewportWidth),
+      Math.round((coords[1] / 1000) * viewportHeight),
+    ];
+
+    const getCoords = (coords?: [number, number]): { x: number; y: number } => {
+      if (!coords || coords.length !== 2) return { x: viewportWidth / 2, y: viewportHeight / 2 };
+      return { x: coords[0], y: coords[1] };
+    };
+
+    const executeAction = async (action: N1Action): Promise<string | undefined> => {
+      switch (action.action_type) {
+        case 'left_click':
+        case 'double_click':
+        case 'triple_click':
+        case 'right_click': {
+          const { x, y } = getCoords(action.coordinates);
+          const button = action.action_type === 'right_click' ? 'right' : 'left';
+          const numClicks = action.action_type === 'double_click' ? 2
+            : action.action_type === 'triple_click' ? 3 : 1;
+          await computer.clickMouse(sessionId, { x, y, button, click_type: 'click', num_clicks: numClicks });
+          await sleep(SCREENSHOT_DELAY_MS);
+          return captureScreenshot();
+        }
+        case 'scroll': {
+          const { x, y } = getCoords(action.coordinates);
+          const notches = Math.max(action.amount ?? 3, 1);
+          let delta_x = 0, delta_y = 0;
+          if (action.direction === 'up') delta_y = -notches;
+          else if (action.direction === 'down') delta_y = notches;
+          else if (action.direction === 'left') delta_x = -notches;
+          else if (action.direction === 'right') delta_x = notches;
+          await computer.scroll(sessionId, { x, y, delta_x, delta_y });
+          await sleep(SCREENSHOT_DELAY_MS);
+          return captureScreenshot();
+        }
+        case 'type': {
+          if (!action.text) throw new Error('text is required for type action');
+          if (action.clear_before_typing) {
+            await computer.pressKey(sessionId, { keys: ['ctrl+a'] });
+            await sleep(100);
+            await computer.pressKey(sessionId, { keys: ['BackSpace'] });
+            await sleep(100);
+          }
+          await computer.typeText(sessionId, { text: action.text, delay: TYPING_DELAY_MS });
+          if (action.press_enter_after) {
+            await sleep(100);
+            await computer.pressKey(sessionId, { keys: ['Return'] });
+          }
+          await sleep(SCREENSHOT_DELAY_MS);
+          return captureScreenshot();
+        }
+        case 'key_press': {
+          if (!action.key_comb) throw new Error('key_comb is required for key_press action');
+          await computer.pressKey(sessionId, { keys: [mapKey(action.key_comb)] });
+          await sleep(SCREENSHOT_DELAY_MS);
+          return captureScreenshot();
+        }
+        case 'hover': {
+          const { x, y } = getCoords(action.coordinates);
+          await computer.moveMouse(sessionId, { x, y });
+          await sleep(SCREENSHOT_DELAY_MS);
+          return captureScreenshot();
+        }
+        case 'drag': {
+          const start = getCoords(action.start_coordinates);
+          const end = getCoords(action.coordinates);
+          await computer.dragMouse(sessionId, {
+            path: [[start.x, start.y], [end.x, end.y]], button: 'left',
+          });
+          await sleep(SCREENSHOT_DELAY_MS);
+          return captureScreenshot();
+        }
+        case 'wait':
+          await sleep(2000);
+          return captureScreenshot();
+        case 'refresh':
+          await computer.pressKey(sessionId, { keys: ['F5'] });
+          await sleep(2000);
+          return captureScreenshot();
+        case 'go_back':
+          await computer.pressKey(sessionId, { keys: ['alt+Left'] });
+          await sleep(1500);
+          return captureScreenshot();
+        case 'goto_url': {
+          if (!action.url) throw new Error('url is required for goto_url action');
+          await computer.pressKey(sessionId, { keys: ['ctrl+l'] });
+          await sleep(ACTION_DELAY_MS);
+          await computer.pressKey(sessionId, { keys: ['ctrl+a'] });
+          await sleep(100);
+          await computer.typeText(sessionId, { text: action.url, delay: TYPING_DELAY_MS });
+          await sleep(ACTION_DELAY_MS);
+          await computer.pressKey(sessionId, { keys: ['Return'] });
+          await sleep(2000);
+          return captureScreenshot();
+        }
+        default:
+          throw new Error(`Unknown action type: ${action.action_type}`);
+      }
+    };
+
+    // Take initial screenshot
+    const initialScreenshot = await captureScreenshot();
+    const conversationMessages: OpenAI.ChatCompletionMessageParam[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: query },
+          { type: 'image_url', image_url: { url: `data:image/webp;base64,${initialScreenshot}` } },
+        ],
+      },
+    ];
+
+    for (let iteration = 0; iteration < maxIterations; iteration++) {
+      const response = await client.chat.completions.create({
+        model,
+        messages: conversationMessages,
+        max_completion_tokens: 4096,
+        temperature: 0.3,
+      });
+
+      const choice = response.choices[0];
+      if (!choice?.message) throw new Error('No response from model');
+
+      conversationMessages.push(choice.message);
+
+      const toolCalls = choice.message.tool_calls;
+      if (!toolCalls || toolCalls.length === 0) {
+        return { result: choice.message.content || '(no response)', provider: this.name };
+      }
+
+      for (const toolCall of toolCalls) {
+        let args: Record<string, unknown>;
+        try {
+          args = JSON.parse(toolCall.function.arguments);
+        } catch {
+          conversationMessages.push({
+            role: 'tool', tool_call_id: toolCall.id,
+            content: 'Error: failed to parse arguments',
+          });
+          continue;
+        }
+
+        const action: N1Action = { action_type: toolCall.function.name as N1ActionType, ...args };
+
+        // Scale coordinates from 1000x1000 to viewport
+        if (action.coordinates) {
+          action.coordinates = scaleCoords(action.coordinates);
+        }
+        if (action.start_coordinates) {
+          action.start_coordinates = scaleCoords(action.start_coordinates);
+        }
+
+        try {
+          const screenshot = await executeAction(action);
+          if (screenshot) {
+            conversationMessages.push({
+              role: 'tool', tool_call_id: toolCall.id,
+              content: [{
+                type: 'image_url',
+                image_url: { url: `data:image/webp;base64,${screenshot}` },
+              }] as unknown as string,
+            });
+          } else {
+            conversationMessages.push({
+              role: 'tool', tool_call_id: toolCall.id, content: 'OK',
+            });
+          }
+        } catch (error) {
+          conversationMessages.push({
+            role: 'tool', tool_call_id: toolCall.id,
+            content: `Action failed: ${error instanceof Error ? error.message : String(error)}`,
+          });
+        }
+      }
+    }
+
+    return { result: '(max iterations reached)', provider: this.name };
+  }
+}


### PR DESCRIPTION
## Summary

Adds three new CUA provider adapters to the unified CUA template factory:

- **Tzafon** (TS + Python) — Northstar CUA model via Lightcone Responses API with function tools and 0-999 coordinate grid
- **Yutori** (TS + Python) — n1-latest model via OpenAI-compatible API with tool_calls, 1000x1000 coordinate space, WebP screenshots
- **OpenAGI** (Python only) — Lux models via oagi SDK with AsyncDefaultAgent, pyautogui/mouseinfo mocking for headless environments

Each adapter is self-contained and follows the existing `CuaProvider` interface pattern. Factory registration, dependencies, env examples, and READMEs updated for both languages.

## Changes

- `providers/tzafon.ts` / `providers/tzafon.py` — Tzafon adapter
- `providers/yutori.ts` / `providers/yutori.py` — Yutori adapter
- `providers/openagi.py` — OpenAGI adapter (Python only, no TS SDK exists)
- `providers/index.ts` / `providers/__init__.py` — Factory registration
- `package.json` / `pyproject.toml` — New dependencies (`@tzafon/lightcone`, `sharp`, `tzafon`, `oagi`, `Pillow`)
- `.env.example` (both) — New API key placeholders
- `README.md` (both) — Provider table and structure docs
- `templates.go` — Updated description

## Test plan

- [ ] Deploy TS template with `CUA_PROVIDER=tzafon` and invoke
- [ ] Deploy TS template with `CUA_PROVIDER=yutori` and invoke
- [ ] Deploy Python template with `CUA_PROVIDER=tzafon` and invoke
- [ ] Deploy Python template with `CUA_PROVIDER=yutori` and invoke
- [ ] Deploy Python template with `CUA_PROVIDER=openagi` and invoke
- [ ] Verify fallback still works across providers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds multiple new third-party provider adapters and dependencies, introducing new network/API interactions and action-execution logic that could affect runtime behavior of the unified CUA template. Risk is contained to templates but failures could surface at deploy/invoke time if provider APIs or coordinate/key mappings differ.
> 
> **Overview**
> Extends the **Unified CUA** templates to support additional providers with fallback: **Tzafon** and **Yutori** in both TypeScript and Python, plus **OpenAGI** in Python.
> 
> Adds new provider adapters implementing the existing CUA interface (Tzafon via Lightcone Responses function tools with 0–999 coords; Yutori via OpenAI-compatible `tool_calls` with 1000×1000 coords and WebP screenshots; OpenAGI via `oagi` Lux agent with headless-safe imports), registers them in the provider factories, and updates template metadata/docs/env examples plus adds required dependencies (`@tzafon/lightcone`, `sharp`, `tzafon`, `oagi`, `Pillow`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55a7a72017d0b0164e71ca782c3053026492e784. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->