### PR TITLE
fix(cua): convert Gemini scroll magnitude pixels to wheel notches

### DIFF
--- a/pkg/templates/python/cua/providers/gemini.py
+++ b/pkg/templates/python/cua/providers/gemini.py
@@ -24,6 +24,11 @@ COORDINATE_SCALE = 1000
 DEFAULT_WIDTH = 1200
 DEFAULT_HEIGHT = 800
 
+# Gemini reports scroll magnitude in pixels; computer.scroll expects wheel
+# notches. Convert with a per-notch pixel budget and clamp to a sane max.
+PX_PER_NOTCH = 60
+MAX_NOTCHES_PER_ACTION = 17
+
 def _system_prompt() -> str:
     date = datetime.now().strftime("%A, %B %d, %Y")
     return (
@@ -169,10 +174,11 @@ class GeminiProvider:
                     y = self._denorm(args.get("y"), height)
                 else:
                     x, y = width // 2, height // 2
-                magnitude = args.get("magnitude", 3)
+                magnitude_px = args.get("magnitude", 400)
+                notches = min(MAX_NOTCHES_PER_ACTION, max(1, round(magnitude_px / PX_PER_NOTCH)))
                 direction = args.get("direction", "down")
-                dy = -magnitude if direction == "up" else magnitude if direction == "down" else 0
-                dx = -magnitude if direction == "left" else magnitude if direction == "right" else 0
+                dy = -notches if direction == "up" else notches if direction == "down" else 0
+                dx = -notches if direction == "left" else notches if direction == "right" else 0
                 await asyncio.to_thread(
                     computer.scroll, options.session_id, x=x, y=y, delta_x=dx, delta_y=dy,
                 )

--- a/pkg/templates/typescript/cua/providers/gemini.ts
+++ b/pkg/templates/typescript/cua/providers/gemini.ts
@@ -18,6 +18,11 @@ const COORDINATE_SCALE = 1000;
 const DEFAULT_WIDTH = 1200;
 const DEFAULT_HEIGHT = 800;
 
+// Gemini reports scroll magnitude in pixels; computer.scroll expects wheel
+// notches. Convert with a per-notch pixel budget and clamp to a sane max.
+const PX_PER_NOTCH = 60;
+const MAX_NOTCHES_PER_ACTION = 17;
+
 const PREDEFINED_ACTIONS = [
   'click_at', 'hover_at', 'type_text_at', 'scroll_document',
   'scroll_at', 'wait_5_seconds', 'go_back', 'go_forward',
@@ -180,10 +185,14 @@ export class GeminiProvider implements CuaProvider {
         case 'scroll_at': {
           const x = name === 'scroll_at' ? this.denormalize(args.x, width) : width / 2;
           const y = name === 'scroll_at' ? this.denormalize(args.y, height) : height / 2;
-          const magnitude = args.magnitude ?? 3;
+          const magnitudePx = args.magnitude ?? 400;
+          const notches = Math.min(
+            MAX_NOTCHES_PER_ACTION,
+            Math.max(1, Math.round(magnitudePx / PX_PER_NOTCH)),
+          );
           const dir = args.direction ?? 'down';
-          const deltaY = dir === 'up' ? -magnitude : dir === 'down' ? magnitude : 0;
-          const deltaX = dir === 'left' ? -magnitude : dir === 'right' ? magnitude : 0;
+          const deltaY = dir === 'up' ? -notches : dir === 'down' ? notches : 0;
+          const deltaX = dir === 'left' ? -notches : dir === 'right' ? notches : 0;
           await computer.scroll(sessionId, { x, y, delta_x: deltaX, delta_y: deltaY });
           break;
         }


### PR DESCRIPTION
## Summary

Stacks on top of the unified CUA template branch. Fixes the Gemini scroll handler bug Danny flagged in review.

Gemini's computer-use API reports scroll `magnitude` in **pixels** (default ~400), but `computer.scroll`'s `delta_x` / `delta_y` expects **wheel notches**. The cua adapter was passing `magnitude` through unchanged, so a default Gemini scroll fired ~400 notches instead of ~7.

The standalone `gemini-computer-use` template already does the right thing — this just brings the unified adapter in line:

- default magnitude: `3` → `400` (pixels, matching Gemini's spec)
- divide by `PX_PER_NOTCH` (60) and clamp to `MAX_NOTCHES_PER_ACTION` (17)
- applied symmetrically in TS (`providers/gemini.ts`) and Python (`providers/gemini.py`)

The `anthropic` and `openai` adapters already match their standalone equivalents — no changes needed there.

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] `go test ./pkg/create/...` passes (verified locally)
- [ ] Deploy CUA template with Gemini provider, ask it to scroll a long page; confirm scroll distance is page-sized, not catastrophic
- [ ] Repeat for Python template

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: localized change to Gemini CUA scrolling that only adjusts how scroll `magnitude` is translated before calling `computer.scroll`.
> 
> **Overview**
> Fixes Gemini CUA scrolling in both the Python and TypeScript templates by treating Gemini-provided scroll `magnitude` as *pixels* and converting it to mouse-wheel *notches* before calling `computer.scroll`.
> 
> Adds `PX_PER_NOTCH` and `MAX_NOTCHES_PER_ACTION` constants, updates the default magnitude to `400`, and clamps the converted notch count to avoid excessively large scroll actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6caa19e08c23c3c3c475e4c7bf28ed496abfece. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->