### PR TITLE
fix(cua): correct Gemini key/drag arg names + safer session cleanup

### DIFF
--- a/pkg/templates/python/cua/providers/gemini.py
+++ b/pkg/templates/python/cua/providers/gemini.py
@@ -210,8 +210,10 @@ class GeminiProvider:
                 await asyncio.sleep(1.5)
 
             elif name == "key_combination":
-                combo = args.get("key_combination", "")
-                parts = [k.strip() for k in combo.split("+")]
+                # Gemini sends the combo as a single "+"-joined string in `keys`.
+                if "keys" not in args:
+                    return {"error": "key_combination requires keys"}
+                parts = [k.strip() for k in str(args["keys"]).split("+")]
                 hold_keys = parts[:-1] if len(parts) > 1 else []
                 keys = parts[-1:] if parts else []
                 kwargs: dict = {"keys": keys or parts}
@@ -222,10 +224,11 @@ class GeminiProvider:
                 )
 
             elif name == "drag_and_drop":
-                sx = self._denorm(args.get("start_x"), width)
-                sy = self._denorm(args.get("start_y"), height)
-                ex = self._denorm(args.get("end_x"), width)
-                ey = self._denorm(args.get("end_y"), height)
+                # Gemini's drag schema uses x/y for the start and destination_x/destination_y for the end.
+                sx = self._denorm(args.get("x"), width)
+                sy = self._denorm(args.get("y"), height)
+                ex = self._denorm(args.get("destination_x"), width)
+                ey = self._denorm(args.get("destination_y"), height)
                 await asyncio.to_thread(
                     computer.drag_mouse, options.session_id, path=[[sx, sy], [ex, ey]],
                 )

--- a/pkg/templates/python/cua/session.py
+++ b/pkg/templates/python/cua/session.py
@@ -114,6 +114,7 @@ class KernelBrowserSession:
         info = self.info
 
         if self._session_id:
+            session_id = self._session_id
             try:
                 if self.opts.record_replay and self._replay_id:
                     if self.opts.replay_grace_period > 0:
@@ -121,15 +122,17 @@ class KernelBrowserSession:
                     await self._stop_replay()
                     info.replay_view_url = self._replay_view_url
             finally:
-                print(f"Destroying browser session: {self._session_id}")
+                # Reset state up front so that if browser deletion or a thrown replay
+                # error propagates, a follow-up stop() call from the caller's error path
+                # is a no-op instead of attempting to delete the same session twice.
+                self._session_id = None
+                self._live_view_url = None
+                self._replay_id = None
+                self._replay_view_url = None
+                print(f"Destroying browser session: {session_id}")
                 await asyncio.to_thread(
-                    self.kernel.browsers.delete_by_id, self._session_id,
+                    self.kernel.browsers.delete_by_id, session_id,
                 )
-
-        self._session_id = None
-        self._live_view_url = None
-        self._replay_id = None
-        self._replay_view_url = None
 
         return info
 

--- a/pkg/templates/typescript/cua/providers/gemini.ts
+++ b/pkg/templates/typescript/cua/providers/gemini.ts
@@ -48,13 +48,11 @@ interface GeminiArgs {
   y?: number;
   text?: string;
   url?: string;
-  key_combination?: string;
+  keys?: string;
   direction?: string;
   magnitude?: number;
-  start_x?: number;
-  start_y?: number;
-  end_x?: number;
-  end_y?: number;
+  destination_x?: number;
+  destination_y?: number;
   safety_decision?: { decision: string; explanation?: string };
   [key: string]: unknown;
 }
@@ -221,8 +219,9 @@ export class GeminiProvider implements CuaProvider {
           break;
         }
         case 'key_combination': {
-          const combo = args.key_combination ?? '';
-          const parts = combo.split('+').map(k => k.trim());
+          // Gemini sends the combo as a single "+"-joined string in `keys`.
+          if (!args.keys) return { error: 'key_combination requires keys' };
+          const parts = args.keys.split('+').map(k => k.trim());
           const holdKeys = parts.slice(0, -1);
           const keys = parts.slice(-1);
           await computer.pressKey(sessionId, {
@@ -232,10 +231,11 @@ export class GeminiProvider implements CuaProvider {
           break;
         }
         case 'drag_and_drop': {
-          const sx = this.denormalize(args.start_x, width);
-          const sy = this.denormalize(args.start_y, height);
-          const ex = this.denormalize(args.end_x, width);
-          const ey = this.denormalize(args.end_y, height);
+          // Gemini's drag schema uses x/y for the start and destination_x/destination_y for the end.
+          const sx = this.denormalize(args.x, width);
+          const sy = this.denormalize(args.y, height);
+          const ex = this.denormalize(args.destination_x, width);
+          const ey = this.denormalize(args.destination_y, height);
           await computer.dragMouse(sessionId, { path: [[sx, sy], [ex, ey]] });
           break;
         }

--- a/pkg/templates/typescript/cua/session.ts
+++ b/pkg/templates/typescript/cua/session.ts
@@ -106,6 +106,7 @@ export class KernelBrowserSession {
     const info = this.info;
 
     if (this._sessionId) {
+      const sessionId = this._sessionId;
       try {
         if (this.opts.recordReplay && this._replayId) {
           if (this.opts.replayGracePeriod > 0) {
@@ -115,15 +116,17 @@ export class KernelBrowserSession {
           info.replayViewUrl = this._replayViewUrl || undefined;
         }
       } finally {
-        console.log(`Destroying browser session: ${this._sessionId}`);
-        await this.kernel.browsers.deleteByID(this._sessionId);
+        // Reset state up front so that if browser deletion or a thrown replay error
+        // propagates, a follow-up stop() call from the caller's error path is a no-op
+        // instead of attempting to delete the same session twice.
+        this._sessionId = null;
+        this._liveViewUrl = null;
+        this._replayId = null;
+        this._replayViewUrl = null;
+        console.log(`Destroying browser session: ${sessionId}`);
+        await this.kernel.browsers.deleteByID(sessionId);
       }
     }
-
-    this._sessionId = null;
-    this._liveViewUrl = null;
-    this._replayId = null;
-    this._replayViewUrl = null;
 
     return info;
   }


### PR DESCRIPTION
## Summary

Stacks on top of the unified CUA template branch. Addresses three of the outstanding Cursor Bugbot findings on PR #143.

### Gemini argument-name mismatches

Both bugs cause the affected actions to be silently/structurally broken — fixed in TS and Python in lockstep with the standalone `gemini-computer-use` templates.

- **`key_combination`** read from `args.key_combination` → now reads `args.keys`. Gemini's schema sends the combo in `keys` (a single `+`-joined string), so the previous code always saw an empty combo and silently dropped every shortcut.
- **`drag_and_drop`** read from `start_x / start_y / end_x / end_y` → now reads `x / y / destination_x / destination_y`. Gemini's schema uses the latter; the previous names always resolved to `0`, so every drag went `(0,0) -> (0,0)`.

### Session cleanup ordering (TS + Python)

`session.stop()` previously placed the state-reset (`_sessionId = null`, …) **after** the `try / finally` that performs replay-stop + browser-delete. If `stopReplay()` threw, the `finally` deleted the browser, the exception then propagated past the cleanup lines, and a follow-up `stop()` from the caller's error path would attempt to delete the already-destroyed session — masking the original error.

Moved the state-reset into the `finally`, so a second `stop()` is a safe no-op regardless of how the first attempt unwound.

### Bugbot findings I checked but did *not* change

These are flagged on the PR but already fixed in the current branch (probably resolved between scans):

- Anthropic system prompt date freezing — already a `getSystemPrompt()` function that reads `new Date()` per task.
- Python `session.py` using `browsers.delete` — already uses `browsers.delete_by_id`.
- Python OpenAI provider missing `screenshot` action — already returns `[]` for `screenshot`.
- Python Gemini dropping screenshots — already appends an `inline_data` `Part` per response when `result["screenshot"]` is set.
- `PREDEFINED_ACTIONS` unused — leftover constant; harmless. Left as-is to keep the diff focused.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/create/...`
- [ ] Deploy CUA template with Gemini provider, ask it to perform a drag, then a keyboard shortcut (e.g. ctrl+a, ctrl+l) — confirm both succeed
- [ ] Force a replay-stop failure (e.g. invalid replay state) and confirm session.stop() can be called twice without crashing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes input parsing for Gemini actions and alters session teardown ordering, which could affect browser lifecycle and replay cleanup if edge cases were missed.
> 
> **Overview**
> Fixes Gemini CUA action argument mismatches in both TS and Python so `key_combination` reads the `keys` "+"-joined string and `drag_and_drop` uses `x`/`y` and `destination_x`/`destination_y`.
> 
> Makes `KernelBrowserSession.stop()` safer by resetting session/replay state inside the `finally` block and deleting the browser using a captured `sessionId`, preventing double-deletes when replay stopping throws.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c6b554c15d8c49736bcf9ecc574bbe7a2785816. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->