### PR TITLE
fix(cua): make session.stop() idempotent on repeated call

### DIFF
--- a/pkg/templates/python/cua/session.py
+++ b/pkg/templates/python/cua/session.py
@@ -111,28 +111,46 @@ class KernelBrowserSession:
         return self.info
 
     async def stop(self) -> SessionInfo:
-        info = self.info
+        session_id = self._session_id
+        if not session_id:
+            # Already stopped — return a snapshot of the (cleared) state without
+            # touching `self.info`, whose `session_id` property raises on None.
+            return SessionInfo(
+                session_id="",
+                live_view_url=self._live_view_url or "",
+                replay_id=self._replay_id,
+                replay_view_url=self._replay_view_url,
+                viewport_width=self.opts.viewport_width,
+                viewport_height=self.opts.viewport_height,
+            )
 
-        if self._session_id:
-            session_id = self._session_id
-            try:
-                if self.opts.record_replay and self._replay_id:
-                    if self.opts.replay_grace_period > 0:
-                        await asyncio.sleep(self.opts.replay_grace_period)
-                    await self._stop_replay()
-                    info.replay_view_url = self._replay_view_url
-            finally:
-                # Reset state up front so that if browser deletion or a thrown replay
-                # error propagates, a follow-up stop() call from the caller's error path
-                # is a no-op instead of attempting to delete the same session twice.
-                self._session_id = None
-                self._live_view_url = None
-                self._replay_id = None
-                self._replay_view_url = None
-                print(f"Destroying browser session: {session_id}")
-                await asyncio.to_thread(
-                    self.kernel.browsers.delete_by_id, session_id,
-                )
+        info = SessionInfo(
+            session_id=session_id,
+            live_view_url=self._live_view_url or "",
+            replay_id=self._replay_id,
+            replay_view_url=self._replay_view_url,
+            viewport_width=self.opts.viewport_width,
+            viewport_height=self.opts.viewport_height,
+        )
+
+        try:
+            if self.opts.record_replay and self._replay_id:
+                if self.opts.replay_grace_period > 0:
+                    await asyncio.sleep(self.opts.replay_grace_period)
+                await self._stop_replay()
+                info.replay_view_url = self._replay_view_url
+        finally:
+            # Reset state up front so that if browser deletion or a thrown replay
+            # error propagates, a follow-up stop() call from the caller's error path
+            # is a no-op instead of attempting to delete the same session twice.
+            self._session_id = None
+            self._live_view_url = None
+            self._replay_id = None
+            self._replay_view_url = None
+            print(f"Destroying browser session: {session_id}")
+            await asyncio.to_thread(
+                self.kernel.browsers.delete_by_id, session_id,
+            )
 
         return info
 

--- a/pkg/templates/typescript/cua/session.ts
+++ b/pkg/templates/typescript/cua/session.ts
@@ -103,29 +103,47 @@ export class KernelBrowserSession {
   }
 
   async stop(): Promise<SessionInfo> {
-    const info = this.info;
+    const sessionId = this._sessionId;
+    if (!sessionId) {
+      // Already stopped — return a snapshot of the (cleared) state without
+      // touching `this.info`, whose `sessionId` getter throws on null.
+      return {
+        sessionId: '',
+        liveViewUrl: this._liveViewUrl ?? '',
+        replayId: this._replayId ?? undefined,
+        replayViewUrl: this._replayViewUrl ?? undefined,
+        viewportWidth: this.opts.viewportWidth,
+        viewportHeight: this.opts.viewportHeight,
+      };
+    }
 
-    if (this._sessionId) {
-      const sessionId = this._sessionId;
-      try {
-        if (this.opts.recordReplay && this._replayId) {
-          if (this.opts.replayGracePeriod > 0) {
-            await sleep(this.opts.replayGracePeriod * 1000);
-          }
-          await this.stopReplay();
-          info.replayViewUrl = this._replayViewUrl || undefined;
+    const info: SessionInfo = {
+      sessionId,
+      liveViewUrl: this._liveViewUrl ?? '',
+      replayId: this._replayId ?? undefined,
+      replayViewUrl: this._replayViewUrl ?? undefined,
+      viewportWidth: this.opts.viewportWidth,
+      viewportHeight: this.opts.viewportHeight,
+    };
+
+    try {
+      if (this.opts.recordReplay && this._replayId) {
+        if (this.opts.replayGracePeriod > 0) {
+          await sleep(this.opts.replayGracePeriod * 1000);
         }
-      } finally {
-        // Reset state up front so that if browser deletion or a thrown replay error
-        // propagates, a follow-up stop() call from the caller's error path is a no-op
-        // instead of attempting to delete the same session twice.
-        this._sessionId = null;
-        this._liveViewUrl = null;
-        this._replayId = null;
-        this._replayViewUrl = null;
-        console.log(`Destroying browser session: ${sessionId}`);
-        await this.kernel.browsers.deleteByID(sessionId);
+        await this.stopReplay();
+        info.replayViewUrl = this._replayViewUrl || undefined;
       }
+    } finally {
+      // Reset state up front so that if browser deletion or a thrown replay error
+      // propagates, a follow-up stop() call from the caller's error path is a no-op
+      // instead of attempting to delete the same session twice.
+      this._sessionId = null;
+      this._liveViewUrl = null;
+      this._replayId = null;
+      this._replayViewUrl = null;
+      console.log(`Destroying browser session: ${sessionId}`);
+      await this.kernel.browsers.deleteByID(sessionId);
     }
 
     return info;


### PR DESCRIPTION
## Summary

Stacks on top of the unified CUA template branch. Addresses the new High-Severity Cursor Bugbot finding on PR #143's latest scan: `stop()` throws on repeated call instead of being a no-op.

## Background

PR #155 moved the session-state reset (`_sessionId = null`, …) into the `finally` so that a thrown replay-stop or browser-delete error wouldn't leave stale state behind. That fix was correct, but it exposed a latent bug: `stop()` opens with `const info = this.info` (TS) / `info = self.info` (Py), and the `info` getter delegates to the `sessionId` property, which raises when `_sessionId` is null. So once PR #155 reliably cleared `_sessionId` on the first call, the caller's error-path retry would hit the throwing getter and mask the original exception — exactly the failure mode PR #155 was meant to prevent.

## Fix

`stop()` now:

1. Short-circuits at the top with a sentinel `SessionInfo` when no session is active — never touches the throwing getter.
2. Builds the live-session `info` from local fields directly so the body never depends on `this.info` / `self.info` either.

Symmetric in TS (`session.ts`) and Python (`session.py`).

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/create/...`
- [ ] Force a replay-stop failure (e.g. delete the replay out-of-band, or pass an invalid replay id) and confirm calling `session.stop()` twice from the caller's error path no longer raises and the original error surfaces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session shutdown/cleanup logic in both Python and TypeScript templates; while small, mistakes could lead to leaked browser sessions or masked errors during teardown.
> 
> **Overview**
> `KernelBrowserSession.stop()` in both `pkg/templates/python/cua/session.py` and `pkg/templates/typescript/cua/session.ts` is updated to be **idempotent**.
> 
> It now short-circuits when no active session exists (returning a sentinel `SessionInfo` without reading `info`/`sessionId`), and builds the returned `SessionInfo` directly from internal fields so teardown can’t fail due to accessing a getter after state has been cleared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db0bdea3d0878119c6d41465d7eb03f4fbe16084. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->