### PR TITLE
fix(cua): nest python gemini screenshots in FunctionResponse, drop unused openai dep

### DIFF
--- a/pkg/templates/python/cua/providers/gemini.py
+++ b/pkg/templates/python/cua/providers/gemini.py
@@ -16,6 +16,9 @@ from google.genai.types import (
     Tool,
     ComputerUse,
     Environment,
+    FunctionResponse,
+    FunctionResponseBlob,
+    FunctionResponsePart,
 )
 
 from . import CuaProvider, TaskOptions, TaskResult
@@ -28,6 +31,13 @@ DEFAULT_HEIGHT = 800
 # notches. Convert with a per-notch pixel budget and clamp to a sane max.
 PX_PER_NOTCH = 60
 MAX_NOTCHES_PER_ACTION = 17
+
+PREDEFINED_ACTIONS = {
+    "click_at", "hover_at", "type_text_at", "scroll_document",
+    "scroll_at", "wait_5_seconds", "go_back", "go_forward",
+    "search", "navigate", "key_combination", "drag_and_drop",
+    "open_web_browser",
+}
 
 def _system_prompt() -> str:
     date = datetime.now().strftime("%A, %B %d, %Y")
@@ -115,20 +125,24 @@ class GeminiProvider:
                 )
 
                 if result.get("error"):
-                    responses.append(Part.from_function_response(
+                    responses.append(Part(function_response=FunctionResponse(
                         name=fc.name,
                         response={"error": result["error"], "url": "about:blank"},
-                    ))
+                    )))
                 else:
-                    responses.append(Part.from_function_response(
+                    fr_parts = None
+                    if result.get("screenshot") and fc.name in PREDEFINED_ACTIONS:
+                        fr_parts = [FunctionResponsePart(
+                            inline_data=FunctionResponseBlob(
+                                mime_type="image/png",
+                                data=result["screenshot"],
+                            ),
+                        )]
+                    responses.append(Part(function_response=FunctionResponse(
                         name=fc.name,
                         response={"url": result.get("url", "about:blank")},
-                    ))
-                    if result.get("screenshot"):
-                        responses.append(Part(inline_data={
-                            "mime_type": "image/png",
-                            "data": result["screenshot"],
-                        }))
+                        parts=fr_parts,
+                    )))
 
             contents.append(Content(role="user", parts=responses))
 

--- a/pkg/templates/python/cua/pyproject.toml
+++ b/pkg/templates/python/cua/pyproject.toml
@@ -9,6 +9,5 @@ dependencies = [
     "google-genai>=1.71.0",
     "httpx>=0.28.1",
     "kernel>=0.47.0",
-    "openai>=2.30.0",
     "python-dotenv>=1.2.2",
 ]


### PR DESCRIPTION
## Summary

Two bugbot findings on commit \`c684ca7\`:

1. **Medium** — Python Gemini provider sent screenshots as a separate \`Part(inline_data=...)\` entry in the user content after the \`FunctionResponse\` part. With multiple function calls per turn the model can't bind a screenshot to its originating call. The standalone \`python/gemini-computer-use\` template and the TS unified template both nest the screenshot as a \`FunctionResponsePart\` inside \`FunctionResponse.parts\`. This PR matches that structure and adds the predefined-actions allowlist that gates screenshot inclusion.

2. **Low** — \`openai\` was listed in \`pyproject.toml\` but never imported. The OpenAI provider uses raw \`httpx\` against the Responses API. Removed.

## Test plan

- [ ] Smoke run python cua with Gemini against a multi-call turn and confirm screenshot binds to the originating call
- [ ] \`uv sync\` after dep change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the structure of Gemini tool-call response parts, which could affect how multi-call turns are interpreted by the model or SDK. Dependency removal is low risk but may impact downstream installs if they relied on the extra package.
> 
> **Overview**
> **Gemini Python CUA now nests screenshots inside each tool call response.** Instead of sending a standalone `Part(inline_data=...)` after the `FunctionResponse`, screenshots are attached as `FunctionResponse.parts` (as `FunctionResponsePart`/`FunctionResponseBlob`) so multi-call turns can reliably associate images with the correct action; screenshot inclusion is gated by a `PREDEFINED_ACTIONS` allowlist.
> 
> **Template deps cleanup.** Removes the unused `openai` dependency from `pyproject.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee48a5cff28207fcf31c0b0b75d31987b641b21f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->