### PR TITLE
add -o json to browsers playwright execute

### DIFF
--- a/cmd/browsers.go
+++ b/cmd/browsers.go
@@ -1326,9 +1326,14 @@ type BrowsersPlaywrightExecuteInput struct {
 	Identifier string
 	Code       string
 	Timeout    int64
+	Output     string
 }
 
 func (b BrowsersCmd) PlaywrightExecute(ctx context.Context, in BrowsersPlaywrightExecuteInput) error {
+	if in.Output != "" && in.Output != "json" {
+		return fmt.Errorf("unsupported --output value: use 'json'")
+	}
+
 	if b.playwright == nil {
 		pterm.Error.Println("playwright service not available")
 		return nil
@@ -1344,6 +1349,10 @@ func (b BrowsersCmd) PlaywrightExecute(ctx context.Context, in BrowsersPlaywrigh
 	res, err := b.playwright.Execute(ctx, br.SessionID, params)
 	if err != nil {
 		return util.CleanedUpSdkError{Err: err}
+	}
+
+	if in.Output == "json" {
+		return util.PrintPrettyJSON(res)
 	}
 
 	rows := pterm.TableData{{"Property", "Value"}, {"Success", fmt.Sprintf("%t", res.Success)}}
@@ -2498,6 +2507,7 @@ func init() {
 	playwrightRoot := &cobra.Command{Use: "playwright", Short: "Playwright operations"}
 	playwrightExecute := &cobra.Command{Use: "execute <id> [code]", Short: "Execute Playwright/TypeScript code against the browser", Args: cobra.MinimumNArgs(1), RunE: runBrowsersPlaywrightExecute}
 	playwrightExecute.Flags().Int64("timeout", 0, "Maximum execution time in seconds (default per server)")
+	playwrightExecute.Flags().StringP("output", "o", "", "Output format: json for raw API response")
 	playwrightRoot.AddCommand(playwrightExecute)
 	browsersCmd.AddCommand(playwrightRoot)
 
@@ -2954,8 +2964,9 @@ func runBrowsersPlaywrightExecute(cmd *cobra.Command, args []string) error {
 		code = string(data)
 	}
 	timeout, _ := cmd.Flags().GetInt64("timeout")
+	output, _ := cmd.Flags().GetString("output")
 	b := BrowsersCmd{browsers: &svc, playwright: &svc.Playwright}
-	return b.PlaywrightExecute(cmd.Context(), BrowsersPlaywrightExecuteInput{Identifier: args[0], Code: strings.TrimSpace(code), Timeout: timeout})
+	return b.PlaywrightExecute(cmd.Context(), BrowsersPlaywrightExecuteInput{Identifier: args[0], Code: strings.TrimSpace(code), Timeout: timeout, Output: output})
 }
 
 func runBrowsersFSNewDirectory(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary

`kernel browsers playwright execute` lacked the `--output/-o` flag that other `browsers` subcommands expose (`create`, `list`, `get`, `view`, `update`, `process exec`, etc.). Add it using the same pattern: `-o json` prints the raw API response via `util.PrintPrettyJSON`, anything else returns the existing pterm tabular output, and unknown values error early.

## Test plan

- [x] `make build` — succeeds
- [x] `make test` — passes
- [x] `./bin/kernel browsers playwright execute --help` shows `-o, --output`
- [ ] manual: `kernel browsers playwright execute <id> 'return 1' -o json` returns valid JSON

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CLI change that only affects formatting/flag parsing for `browsers playwright execute`, with an early validation error for unsupported `--output` values.
> 
> **Overview**
> Adds `--output/-o` to `kernel browsers playwright execute` to match other `browsers` subcommands.
> 
> When `-o json` is provided, the command now prints the raw `Execute` API response via `util.PrintPrettyJSON`; otherwise it keeps the existing table/stdout/stderr rendering, and invalid `--output` values fail fast.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d05c65a6bbeb0cad74abb8d531943bfb63c3a80c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->