### PR TITLE
list templates + languages in 'kernel create --help'

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -88,12 +88,9 @@ func init() {
 func supportedLanguageDisplay() []string {
 	out := make([]string, 0, len(create.SupportedLanguages))
 	for _, l := range create.SupportedLanguages {
-		switch l {
-		case create.LanguageTypeScript:
-			out = append(out, l+"|"+create.LanguageShorthandTypeScript)
-		case create.LanguagePython:
-			out = append(out, l+"|"+create.LanguageShorthandPython)
-		default:
+		if s := create.LanguageShorthand(l); s != "" {
+			out = append(out, l+"|"+s)
+		} else {
 			out = append(out, l)
 		}
 	}
@@ -111,12 +108,9 @@ func buildCreateLongHelp() string {
 
 	b.WriteString("Languages:\n")
 	for _, l := range create.SupportedLanguages {
-		switch l {
-		case create.LanguageTypeScript:
-			fmt.Fprintf(&b, "  %s (shorthand: %s)\n", l, create.LanguageShorthandTypeScript)
-		case create.LanguagePython:
-			fmt.Fprintf(&b, "  %s (shorthand: %s)\n", l, create.LanguageShorthandPython)
-		default:
+		if s := create.LanguageShorthand(l); s != "" {
+			fmt.Fprintf(&b, "  %s (shorthand: %s)\n", l, s)
+		} else {
 			fmt.Fprintf(&b, "  %s\n", l)
 		}
 	}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/kernel/cli/pkg/create"
 	"github.com/pterm/pterm"
@@ -67,14 +69,80 @@ func (c CreateCmd) Create(ctx context.Context, ci create.CreateInput) error {
 var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new application",
-	Long:  "Commands for creating new Kernel applications",
-	RunE:  runCreateApp,
+	Long:  buildCreateLongHelp(),
+	Example: strings.Join([]string{
+		"create --name my-app --language typescript --template anthropic-computer-use",
+		"create -n my-app -l py -t sample-app",
+	}, "\n"),
+	RunE: runCreateApp,
 }
 
 func init() {
 	createCmd.Flags().StringP("name", "n", "", "Name of the application")
-	createCmd.Flags().StringP("language", "l", "", "Language of the application")
-	createCmd.Flags().StringP("template", "t", "", "Template to use for the application")
+	createCmd.Flags().StringP("language", "l", "", fmt.Sprintf("Language of the application (%s)", strings.Join(supportedLanguageDisplay(), ", ")))
+	createCmd.Flags().StringP("template", "t", "", "Template to use for the application (see 'kernel create --help' for the full list)")
+}
+
+// supportedLanguageDisplay returns each supported language with its shorthand,
+// e.g. ["typescript|ts", "python|py"], for inline flag-usage hints.
+func supportedLanguageDisplay() []string {
+	out := make([]string, 0, len(create.SupportedLanguages))
+	for _, l := range create.SupportedLanguages {
+		switch l {
+		case create.LanguageTypeScript:
+			out = append(out, l+"|"+create.LanguageShorthandTypeScript)
+		case create.LanguagePython:
+			out = append(out, l+"|"+create.LanguageShorthandPython)
+		default:
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// buildCreateLongHelp renders the Long help text for `kernel create`,
+// listing supported languages and every template (with descriptions and
+// which languages it supports) so agents and scripts can pick non-interactively.
+func buildCreateLongHelp() string {
+	var b strings.Builder
+	b.WriteString("Commands for creating new Kernel applications.\n\n")
+	b.WriteString("Pass --name, --language and --template to scaffold non-interactively;\n")
+	b.WriteString("any omitted flag falls back to an interactive prompt.\n\n")
+
+	b.WriteString("Languages:\n")
+	for _, l := range create.SupportedLanguages {
+		switch l {
+		case create.LanguageTypeScript:
+			fmt.Fprintf(&b, "  %s (shorthand: %s)\n", l, create.LanguageShorthandTypeScript)
+		case create.LanguagePython:
+			fmt.Fprintf(&b, "  %s (shorthand: %s)\n", l, create.LanguageShorthandPython)
+		default:
+			fmt.Fprintf(&b, "  %s\n", l)
+		}
+	}
+
+	keys := make([]string, 0, len(create.Templates))
+	for k := range create.Templates {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	keyWidth := 0
+	for _, k := range keys {
+		if len(k) > keyWidth {
+			keyWidth = len(k)
+		}
+	}
+
+	b.WriteString("\nTemplates:\n")
+	for _, k := range keys {
+		info := create.Templates[k]
+		langs := append([]string(nil), info.Languages...)
+		sort.Strings(langs)
+		fmt.Fprintf(&b, "  %-*s  %s [%s]\n", keyWidth, k, info.Description, strings.Join(langs, ", "))
+	}
+
+	return strings.TrimRight(b.String(), "\n")
 }
 
 func runCreateApp(cmd *cobra.Command, args []string) error {

--- a/pkg/create/types.go
+++ b/pkg/create/types.go
@@ -56,3 +56,16 @@ func NormalizeLanguage(language string) string {
 		return language
 	}
 }
+
+// LanguageShorthand returns the shorthand for a canonical language name,
+// or an empty string if the language has no shorthand. Inverse of NormalizeLanguage.
+func LanguageShorthand(language string) string {
+	switch language {
+	case LanguageTypeScript:
+		return LanguageShorthandTypeScript
+	case LanguagePython:
+		return LanguageShorthandPython
+	default:
+		return ""
+	}
+}

--- a/pkg/create/types_test.go
+++ b/pkg/create/types_test.go
@@ -24,3 +24,22 @@ func TestNormalizeLanguage(t *testing.T) {
 		})
 	}
 }
+
+func TestLanguageShorthand(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"typescript", "ts"},
+		{"python", "py"},
+		{"ts", ""},
+		{"unknown", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := LanguageShorthand(tt.input)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- \`kernel create --help\` now lists every supported language (with shorthand) and every template (with description + supported languages), so scripts and agents can pick \`--language\` / \`--template\` non-interactively without dropping into the prompt
- Help text is generated from \`create.Templates\` and \`create.SupportedLanguages\`, so it stays in sync as templates are added
- Added two \`Example\` lines showing the non-interactive flag form

before:
\`\`\`
FLAGS
  -l --language  Language of the application
  -t --template  Template to use for the application
\`\`\`

after:
\`\`\`
Languages:
  typescript (shorthand: ts)
  python (shorthand: py)

Templates:
  anthropic-computer-use  Implements an Anthropic computer use agent [python, typescript]
  browser-use             Implements Browser Use SDK [python]
  ...
\`\`\`

## Test plan

- [x] \`go test -short ./cmd/... ./pkg/create/...\` passes
- [x] \`kernel create --help\` renders languages + templates list and examples
- [ ] sanity check the rendered help on a terminal with non-trivial width

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CLI help/flag text generation plus a small pure function with unit tests; no scaffolding logic or data paths are modified.
> 
> **Overview**
> `kernel create` help output is expanded and generated dynamically: the long description now lists all supported languages (including shorthands) and every template with its description and supported languages, and the command adds concrete non-interactive usage examples.
> 
> Flag help text is updated to hint available language values and direct users to `--help` for the template list. A new `create.LanguageShorthand` helper (with tests) supports rendering shorthand info alongside canonical language names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 632958373dc64333927de6b988fd8f7f157c635f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->