### PR TITLE
feat: add nix flake for reproducible builds

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,42 @@
+{
+  description = "Kernel CLI — cloud browser infrastructure for AI agents";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        version = "0.19.0";
+      in {
+        packages.default = pkgs.buildGoModule {
+          pname = "kernel";
+          inherit version;
+
+          src = ./.;
+
+          vendorHash = "sha256-l/r3aRCu3cViGmb7wt0GMwnwRwXytTo8C74zL6rAMlU=";
+
+          ldflags = [
+            "-s"
+            "-w"
+            "-X main.version=${version}"
+          ];
+
+          meta = with pkgs.lib; {
+            description = "Kernel CLI — cloud browser infrastructure for AI agents";
+            homepage = "https://www.kernel.sh";
+            license = licenses.asl20;
+            mainProgram = "kernel";
+            platforms = platforms.unix;
+          };
+        };
+
+        apps.default = flake-utils.lib.mkApp {
+          drv = self.packages.${system}.default;
+        };
+      });
+}


### PR DESCRIPTION
## Summary

Adds a `flake.nix` that exposes the CLI as a [Nix](https://nixos.org) package. Nix users can install or run the CLI directly from this repository without Homebrew or npm, with reproducibility on Linux, macOS, and other Unix-like systems.

```bash
nix build github:kernel/cli                # produces ./result/bin/kernel
nix run  github:kernel/cli -- --help       # one-shot run
nix profile install github:kernel/cli      # add to user profile
```

The flake mirrors the `ldflags` from `.goreleaser.yaml` so `kernel --version` reports the pinned version. The output binary matches `make build` semantically. No Go source is touched — addition is `flake.nix` + `flake.lock` only.

## Test plan

- [x] `make test` — passes (go vet + go test ./...)
- [x] `nix build` on `aarch64-darwin` — produces a working `kernel` binary
- [x] Built binary reports correct version: `kernel 0.19.0 (none) go1.26.2 unknown`
- [x] `nix run .# -- --version` works
- [x] Production smoke: `kernel auth`, `kernel browsers create --stealth`, `kernel browsers list` all work against prod with the nix-built binary

## Notes

- `version` and `vendorHash` are pinned in `flake.nix` and will need to be bumped per release alongside the existing goreleaser bump. [`nix-update`](https://github.com/Mic92/nix-update) is the standard tool for automating this.
- Minimal scope: no devShell, no flake-check CI job, no README changes. Easy to extend later if there's demand.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds Nix packaging metadata only; no Go/runtime behavior changes beyond how the binary is built and versioned.
> 
> **Overview**
> Adds a new Nix flake (`flake.nix` + `flake.lock`) that packages the Go-based `kernel` CLI using `buildGoModule` across default systems.
> 
> The flake pins `nixpkgs`/`flake-utils`, sets a fixed `vendorHash`, and applies `ldflags` (including `-X main.version=0.19.0`) so Nix-built binaries report the expected version and can be exposed via `packages.default` and `apps.default`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 032ab59ef3b55eba087529f9cc1fc40955e56185. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->