### PR TITLE
yutori template: align with Yutori n1.5 recommendations and fix runtime/type issues

### DIFF
--- a/pkg/create/templates.go
+++ b/pkg/create/templates.go
@@ -219,7 +219,7 @@ var Commands = map[string]map[string]DeployConfig{
 		TemplateYutoriComputerUse: {
 			EntryPoint:    "index.ts",
 			NeedsEnvFile:  true,
-			InvokeCommand: `kernel invoke ts-yutori-cua cua-task --payload '{"query": "Navigate to https://example.com and describe the page"}'`,
+			InvokeCommand: `kernel invoke ts-yutori-cua cua-task --payload '{"query": "Navigate to https://www.yutori.com and list the team member names."}'`,
 		},
 		TemplateTzafonComputerUse: {
 			EntryPoint:    "index.ts",
@@ -271,7 +271,7 @@ var Commands = map[string]map[string]DeployConfig{
 		TemplateYutoriComputerUse: {
 			EntryPoint:    "main.py",
 			NeedsEnvFile:  true,
-			InvokeCommand: `kernel invoke python-yutori-cua cua-task --payload '{"query": "Navigate to https://example.com and describe the page"}'`,
+			InvokeCommand: `kernel invoke python-yutori-cua cua-task --payload '{"query": "Navigate to https://www.yutori.com and list the team member names."}'`,
 		},
 		TemplateTzafonComputerUse: {
 			EntryPoint:    "main.py",

--- a/pkg/templates/python/yutori/README.md
+++ b/pkg/templates/python/yutori/README.md
@@ -22,6 +22,18 @@ kernel deploy main.py --env-file .env
 ## Usage
 
 ```bash
+kernel invoke python-yutori-cua cua-task --payload '{"query": "Navigate to https://www.yutori.com and list the team member names."}'
+```
+
+Optional payload fields:
+
+- `record_replay` (bool) — capture a video of the session (paid plans only).
+- `kiosk` (bool) — launch the browser without address bar / tabs ([see below](#kiosk-mode)).
+- `user_timezone` (IANA, e.g. `"America/New_York"`) and `user_location` (free text, e.g. `"New York, NY, US"`) — appended to the task message so the model has accurate temporal/locational grounding.
+
+More involved example (Kanban drag-and-drop):
+
+```bash
 kernel invoke python-yutori-cua cua-task --payload '{"query": "Go to https://www.magnitasks.com, Click the Tasks option in the left-side bar, and drag the 5 items in the To Do and In Progress columns to the Done section of the Kanban board. You are done successfully when the items are dragged to Done. Do not click into the items."}'
 ```
 

--- a/pkg/templates/python/yutori/loop.py
+++ b/pkg/templates/python/yutori/loop.py
@@ -11,6 +11,8 @@ n1.5-latest uses an OpenAI-compatible API with tool_calls:
 @see https://docs.yutori.com/reference/n1-5
 """
 
+from __future__ import annotations
+
 import copy
 import json
 import platform
@@ -225,15 +227,15 @@ async def sampling_loop(
 
 def _format_task_with_context(task: str, user_timezone: str, user_location: str) -> str:
     """Append location, timezone, and current date/time to the task message."""
-    try:
-        tz = ZoneInfo(user_timezone)
-        tz_label = user_timezone
-    except (ZoneInfoNotFoundError, ValueError, OSError):
+    for timezone_name in [user_timezone, "America/Los_Angeles", "UTC"]:
         try:
-            tz = ZoneInfo("UTC")
-            tz_label = "UTC"
-        except (ZoneInfoNotFoundError, OSError):
-            return task
+            tz = ZoneInfo(timezone_name)
+            tz_label = timezone_name
+            break
+        except (ZoneInfoNotFoundError, ValueError, OSError):
+            continue
+    else:
+        return task
 
     now = datetime.now(tz)
     day_fmt = "%#d" if platform.system() == "Windows" else "%-d"

--- a/pkg/templates/python/yutori/loop.py
+++ b/pkg/templates/python/yutori/loop.py
@@ -13,7 +13,10 @@ n1.5-latest uses an OpenAI-compatible API with tool_calls:
 
 import copy
 import json
+import platform
+from datetime import datetime
 from typing import Any, Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from kernel import Kernel
 from openai import OpenAI
@@ -25,6 +28,8 @@ from tools import ComputerTool, N15Action, ToolResult
 # exclusion is explicit and survives if the default ever changes.
 DISABLED_TOOLS = ["extract_elements", "find", "set_element_value", "execute_js"]
 TOOL_SET = "browser_tools_core-20260403"
+
+NAVIGATOR_COORDINATE_SCALE = 1000
 
 # Screenshot-trimming defaults mirror Yutori's reference loop:
 # https://github.com/yutori-ai/yutori-sdk-python/blob/main/yutori/navigator/payload.py
@@ -42,12 +47,14 @@ async def sampling_loop(
     kernel: Kernel,
     session_id: str,
     max_completion_tokens: int = 4096,
-    max_iterations: int = 50,
+    max_iterations: int = 100,
     viewport_width: int = 1280,
     viewport_height: int = 800,
     kiosk_mode: bool = False,
+    user_timezone: str = "America/Los_Angeles",
+    user_location: str = "San Francisco, CA, US",
 ) -> dict[str, Any]:
-    """Run the n1 sampling loop until the model stops calling tools or max iterations."""
+    """Run the n1.5 sampling loop until the model stops calling tools or max iterations."""
     client = OpenAI(
         api_key=api_key,
         base_url="https://api.yutori.com/v1",
@@ -57,7 +64,12 @@ async def sampling_loop(
 
     initial_screenshot = await computer_tool.screenshot()
 
-    user_content: list[dict[str, Any]] = [{"type": "text", "text": task}]
+    # Append location/timezone/current-date context to the task — mirrors Yutori's
+    # format_task_with_context helper and helps the model with date-sensitive
+    # judgments. https://github.com/yutori-ai/yutori-sdk-python/blob/main/yutori/navigator/context.py
+    task_with_context = _format_task_with_context(task, user_timezone, user_location)
+
+    user_content: list[dict[str, Any]] = [{"type": "text", "text": task_with_context}]
     if initial_screenshot.get("base64_image"):
         user_content.append({
             "type": "image_url",
@@ -171,13 +183,79 @@ async def sampling_loop(
                     "content": result.get("output", "OK"),
                 })
 
-    if iteration >= max_iterations:
-        print("Max iterations reached")
+    # If the loop exhausted iterations, prompt the model for a final summary so
+    # the caller gets a usable answer instead of empty content. Mirrors Yutori's
+    # format_stop_and_summarize helper.
+    if iteration >= max_iterations and not final_answer:
+        print("Max iterations reached — requesting summary")
+        try:
+            final_screenshot = await computer_tool.screenshot()
+            stop_content: list[dict[str, Any]] = [
+                {"type": "text", "text": _format_stop_and_summarize(task)}
+            ]
+            if final_screenshot.get("base64_image"):
+                stop_content.append({
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/webp;base64,{final_screenshot['base64_image']}"
+                    },
+                })
+            conversation_messages.append({"role": "user", "content": stop_content})
+
+            summary_messages, _ = _trimmed_for_request(conversation_messages)
+            summary_response = client.chat.completions.create(
+                model=model,
+                messages=summary_messages,
+                max_completion_tokens=max_completion_tokens,
+                temperature=0.3,
+                extra_body={"tool_set": TOOL_SET, "disable_tools": DISABLED_TOOLS},
+            )
+            summary = summary_response.choices[0].message if summary_response.choices else None
+            if summary:
+                conversation_messages.append(summary.model_dump(exclude_none=True))
+                final_answer = summary.content or None
+        except Exception as summary_error:
+            print(f"Stop-and-summarize call failed: {summary_error}")
 
     return {
         "messages": conversation_messages,
         "final_answer": final_answer,
     }
+
+
+def _format_task_with_context(task: str, user_timezone: str, user_location: str) -> str:
+    """Append location, timezone, and current date/time to the task message."""
+    try:
+        tz = ZoneInfo(user_timezone)
+        tz_label = user_timezone
+    except (ZoneInfoNotFoundError, ValueError, OSError):
+        try:
+            tz = ZoneInfo("UTC")
+            tz_label = "UTC"
+        except (ZoneInfoNotFoundError, OSError):
+            return task
+
+    now = datetime.now(tz)
+    day_fmt = "%#d" if platform.system() == "Windows" else "%-d"
+    context = "\n".join([
+        f"User's location: {user_location}",
+        f"User's timezone: {tz_label}",
+        f"Current Date: {now.strftime(f'%B {day_fmt}, %Y')}",
+        f"Current Time: {now.strftime('%H:%M:%S %Z')}",
+        f"Today is: {now.strftime('%A')}",
+    ])
+    return f"{task}\n\n{context}"
+
+
+def _format_stop_and_summarize(task: str) -> str:
+    return (
+        f"Stop here. "
+        f"Summarize your current progress and list in detail all the findings "
+        f"relevant to the given task:\n{task}\n"
+        f"Provide URLs for all relevant results you find and return them in your response. "
+        f"If there is no specific URL for a result, "
+        f"cite the page URL that the information was found on."
+    )
 
 
 def _trimmed_for_request(
@@ -263,17 +341,22 @@ def _scale_coordinates(action: N15Action, viewport_width: int, viewport_height: 
     scaled = dict(action)
 
     if "coordinates" in scaled and scaled["coordinates"]:
-        coords = scaled["coordinates"]
-        scaled["coordinates"] = [
-            round((coords[0] / 1000) * viewport_width),
-            round((coords[1] / 1000) * viewport_height),
-        ]
+        scaled["coordinates"] = _denormalize(scaled["coordinates"], viewport_width, viewport_height)
 
     if "start_coordinates" in scaled and scaled["start_coordinates"]:
-        coords = scaled["start_coordinates"]
-        scaled["start_coordinates"] = [
-            round((coords[0] / 1000) * viewport_width),
-            round((coords[1] / 1000) * viewport_height),
-        ]
+        scaled["start_coordinates"] = _denormalize(scaled["start_coordinates"], viewport_width, viewport_height)
 
     return scaled
+
+
+def _denormalize(coords: list[int] | tuple[int, int], width: int, height: int) -> list[int]:
+    """Map [0, 1000] coordinates to viewport pixels and clamp to [0, dim-1].
+
+    Clamping prevents a boundary value like 1000 from landing one pixel outside
+    the viewport on a 1280x800 display.
+    """
+    raw_x = round((coords[0] / NAVIGATOR_COORDINATE_SCALE) * width)
+    raw_y = round((coords[1] / NAVIGATOR_COORDINATE_SCALE) * height)
+    x = max(0, min(width - 1, raw_x))
+    y = max(0, min(height - 1, raw_y))
+    return [x, y]

--- a/pkg/templates/python/yutori/main.py
+++ b/pkg/templates/python/yutori/main.py
@@ -6,12 +6,15 @@ from loop import sampling_loop
 from session import KernelBrowserSession
 
 
-class QueryInput(TypedDict, total=False):
-    query: str
+class _QueryInputOptional(TypedDict, total=False):
     record_replay: Optional[bool]
     kiosk: Optional[bool]
     user_timezone: Optional[str]
     user_location: Optional[str]
+
+
+class QueryInput(_QueryInputOptional):
+    query: str
 
 
 class QueryOutput(TypedDict):

--- a/pkg/templates/python/yutori/main.py
+++ b/pkg/templates/python/yutori/main.py
@@ -6,10 +6,12 @@ from loop import sampling_loop
 from session import KernelBrowserSession
 
 
-class QueryInput(TypedDict):
+class QueryInput(TypedDict, total=False):
     query: str
     record_replay: Optional[bool]
     kiosk: Optional[bool]
+    user_timezone: Optional[str]
+    user_location: Optional[str]
 
 
 class QueryOutput(TypedDict):
@@ -37,6 +39,9 @@ async def cua_task(
         payload: An object containing:
             - query: The task/query string to process
             - record_replay: Optional boolean to enable video replay recording
+            - kiosk: Optional boolean to launch in kiosk mode
+            - user_timezone: Optional IANA tz (e.g. "America/New_York")
+            - user_location: Optional free-text location for model context
 
     Returns:
         A dictionary containing:
@@ -57,16 +62,22 @@ async def cua_task(
     ) as session:
         print("Kernel browser live view url:", session.live_view_url)
 
-        loop_result = await sampling_loop(
-            model="n1.5-latest",
-            task=payload["query"],
-            api_key=str(api_key),
-            kernel=session.kernel,
-            session_id=str(session.session_id),
-            viewport_width=session.viewport_width,
-            viewport_height=session.viewport_height,
-            kiosk_mode=kiosk_mode,
-        )
+        loop_kwargs: dict = {
+            "model": "n1.5-latest",
+            "task": payload["query"],
+            "api_key": str(api_key),
+            "kernel": session.kernel,
+            "session_id": str(session.session_id),
+            "viewport_width": session.viewport_width,
+            "viewport_height": session.viewport_height,
+            "kiosk_mode": kiosk_mode,
+        }
+        if payload.get("user_timezone"):
+            loop_kwargs["user_timezone"] = payload["user_timezone"]
+        if payload.get("user_location"):
+            loop_kwargs["user_location"] = payload["user_location"]
+
+        loop_result = await sampling_loop(**loop_kwargs)
 
         final_answer = loop_result.get("final_answer")
         messages = loop_result.get("messages", [])
@@ -74,7 +85,6 @@ async def cua_task(
         if final_answer:
             result = final_answer
         else:
-            # Extract last assistant message
             result = _extract_last_assistant_message(messages)
 
     return {

--- a/pkg/templates/python/yutori/pyproject.toml
+++ b/pkg/templates/python/yutori/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "python-yutori-cua"
 version = "0.1.0"
-description = "Kernel reference app for Yutori n1 Computer Use"
+description = "Kernel reference app for Yutori n1.5 Computer Use"
 requires-python = ">=3.9"
 dependencies = [
     "openai>=1.58.0",

--- a/pkg/templates/python/yutori/tools/computer.py
+++ b/pkg/templates/python/yutori/tools/computer.py
@@ -22,6 +22,18 @@ TYPING_DELAY_MS = 12
 SCREENSHOT_DELAY_S = 0.15
 ACTION_DELAY_S = 0.3
 
+# n1.5 scroll `amount` is in "wheel units" where 1 unit ≈ 10% of the viewport
+# height (~80px at 800px tall). Kernel's delta_y is a wheel-event repeat count
+# where each tick is much smaller in practice, so we multiply.
+SCROLL_NOTCHES_PER_AMOUNT = 4
+
+# WebP quality for screenshots. Kernel returns PNGs, which are crisp and
+# tolerate aggressive WebP compression with no visible degradation — matches
+# Yutori SDK's DEFAULT_WEBP_QUALITY_FOR_PNG=30 (yutori-sdk-python/yutori/
+# navigator/images.py). Lower values cut payload size substantially on long
+# multi-step trajectories.
+WEBP_QUALITY = 30
+
 N15ActionType = Literal[
     "left_click",
     "double_click",
@@ -57,43 +69,80 @@ class N15Action(TypedDict, total=False):
     url: str
 
 
-KEY_MAP = {
-    "Enter": "Return",
-    "Escape": "Escape",
-    "Backspace": "BackSpace",
-    "Tab": "Tab",
-    "Delete": "Delete",
-    "ArrowUp": "Up",
-    "ArrowDown": "Down",
-    "ArrowLeft": "Left",
-    "ArrowRight": "Right",
-    "Home": "Home",
-    "End": "End",
-    "PageUp": "Page_Up",
-    "PageDown": "Page_Down",
-    "F1": "F1",
-    "F2": "F2",
-    "F3": "F3",
-    "F4": "F4",
-    "F5": "F5",
-    "F6": "F6",
-    "F7": "F7",
-    "F8": "F8",
-    "F9": "F9",
-    "F10": "F10",
-    "F11": "F11",
-    "F12": "F12",
+# n1.5 emits lowercase key names (e.g. `enter`, `ctrl+c`, `down down down enter`).
+# Kernel's press_key expects XKeysym names (e.g. `Return`, `Ctrl`, `Page_Up`).
+# Keys not in the map pass through unchanged (printable characters like `a`,
+# `1`, `,` are already XKeysym).
+#
+# Sister implementation (Playwright target instead of XKeysym):
+# https://github.com/yutori-ai/yutori-sdk-python/blob/main/yutori/navigator/keys.py
+KEY_MAP: dict[str, str] = {
+    # Modifiers
+    "ctrl": "Ctrl",
+    "control": "Ctrl",
+    "shift": "Shift",
+    "alt": "Alt",
+    "meta": "Super_L",
+    "command": "Super_L",
+    "cmd": "Super_L",
+    "super": "Super_L",
+    "option": "Alt",
+    # Enter
+    "enter": "Return",
+    "return": "Return",
+    # Navigation
+    "tab": "Tab",
+    "backspace": "BackSpace",
+    "delete": "Delete",
+    "escape": "Escape",
+    "esc": "Escape",
+    "space": "space",
+    # Arrows
+    "up": "Up",
+    "down": "Down",
+    "left": "Left",
+    "right": "Right",
+    "arrowup": "Up",
+    "arrowdown": "Down",
+    "arrowleft": "Left",
+    "arrowright": "Right",
+    # Page nav
+    "home": "Home",
+    "end": "End",
+    "pageup": "Page_Up",
+    "pagedown": "Page_Down",
+    # Function keys
+    **{f"f{i}": f"F{i}" for i in range(1, 13)},
+    # Locks / special
+    "capslock": "Caps_Lock",
+    "numlock": "Num_Lock",
+    "scrolllock": "Scroll_Lock",
+    "insert": "Insert",
+    "pause": "Pause",
+    "printscreen": "Print",
 }
 
-MODIFIER_MAP = {
-    "control": "ctrl",
-    "ctrl": "ctrl",
-    "alt": "alt",
-    "shift": "shift",
-    "meta": "super",
-    "command": "super",
-    "cmd": "super",
-}
+
+def _map_token(token: str) -> str:
+    lower = token.strip().lower()
+    return KEY_MAP.get(lower, token.strip())
+
+
+def _parse_key_expression(expr: str) -> list[str]:
+    """Parse an n1.5 key expression into one Kernel combo per sequential press.
+
+    Spaces separate sequential presses; '+' separates simultaneous tokens
+    within a press. Examples:
+        "enter"             -> ["Return"]
+        "ctrl+c"            -> ["Ctrl+c"]
+        "down down enter"   -> ["Down", "Down", "Return"]
+        "ctrl+shift+t"      -> ["Ctrl+Shift+t"]
+    """
+    return [
+        "+".join(_map_token(token) for token in combo.split("+"))
+        for combo in expr.strip().split()
+        if combo
+    ]
 
 
 class ComputerTool:
@@ -145,7 +194,7 @@ class ComputerTool:
             "num_clicks": num_clicks,
         }
         if modifier:
-            kwargs["hold_keys"] = [self._map_key(modifier)]
+            kwargs["hold_keys"] = [_map_token(modifier)]
 
         self.kernel.browsers.computer.click_mouse(self.session_id, **kwargs)
 
@@ -181,23 +230,25 @@ class ComputerTool:
     async def _handle_scroll(self, action: N15Action) -> ToolResult:
         coords = self._get_coordinates(action.get("coordinates"))
         direction = action.get("direction")
-        notches = max(action.get("amount", 3), 1)
+        amount = max(action.get("amount", 3), 1)
 
         if direction not in ("up", "down", "left", "right"):
             raise ToolError(f"Invalid scroll direction: {direction}")
 
-        # Backend (kernel-images) uses delta_x/delta_y as wheel-event repeat count (notches), not pixels.
+        # Yutori 1 unit ≈ 10% of viewport height; scale into Kernel wheel-event ticks.
+        ticks = amount * SCROLL_NOTCHES_PER_AMOUNT
+
         delta_x = 0
         delta_y = 0
 
         if direction == "up":
-            delta_y = -notches
+            delta_y = -ticks
         elif direction == "down":
-            delta_y = notches
+            delta_y = ticks
         elif direction == "left":
-            delta_x = -notches
+            delta_x = -ticks
         elif direction == "right":
-            delta_x = notches
+            delta_x = ticks
 
         modifier = action.get("modifier")
         scroll_kwargs: dict[str, Any] = {
@@ -207,13 +258,13 @@ class ComputerTool:
             "delta_y": delta_y,
         }
         if modifier:
-            scroll_kwargs["hold_keys"] = [self._map_key(modifier)]
+            scroll_kwargs["hold_keys"] = [_map_token(modifier)]
 
         self.kernel.browsers.computer.scroll(self.session_id, **scroll_kwargs)
 
         await asyncio.sleep(SCREENSHOT_DELAY_S)
         screenshot_result = await self.screenshot()
-        screenshot_result["output"] = f"Scrolled {notches} wheel unit(s) {direction}."
+        screenshot_result["output"] = f"Scrolled {amount} unit(s) {direction}."
         return screenshot_result
 
     async def _handle_type(self, action: N15Action) -> ToolResult:
@@ -235,12 +286,11 @@ class ComputerTool:
         if not key:
             raise ToolError("key is required for key_press action")
 
-        mapped_key = self._map_key(key)
-
-        self.kernel.browsers.computer.press_key(
-            self.session_id,
-            keys=[mapped_key],
-        )
+        # n1.5 supports sequential presses ("down down down enter") — issue each
+        # combo as its own press_key so they're seen as separate keystrokes.
+        combos = _parse_key_expression(key)
+        for combo in combos:
+            self.kernel.browsers.computer.press_key(self.session_id, keys=[combo])
 
         await asyncio.sleep(SCREENSHOT_DELAY_S)
         return await self.screenshot()
@@ -250,16 +300,17 @@ class ComputerTool:
         if not key:
             raise ToolError("key is required for hold_key action")
 
-        mapped_key = self._map_key(key)
         # Yutori emits `duration` in seconds; Kernel SDK's press_key takes ms.
         duration_s = action.get("duration")
         duration_ms = int(duration_s * 1000) if duration_s and duration_s > 0 else 1000
 
-        self.kernel.browsers.computer.press_key(
-            self.session_id,
-            keys=[mapped_key],
-            duration=duration_ms,
-        )
+        combos = _parse_key_expression(key)
+        for combo in combos:
+            self.kernel.browsers.computer.press_key(
+                self.session_id,
+                keys=[combo],
+                duration=duration_ms,
+            )
 
         await asyncio.sleep(SCREENSHOT_DELAY_S)
         return await self.screenshot()
@@ -295,7 +346,7 @@ class ComputerTool:
     async def _handle_go_back(self, action: N15Action) -> ToolResult:
         self.kernel.browsers.computer.press_key(
             self.session_id,
-            keys=["alt+Left"],
+            keys=["Alt+Left"],
         )
         await asyncio.sleep(1.5)
         return await self.screenshot()
@@ -303,7 +354,7 @@ class ComputerTool:
     async def _handle_go_forward(self, action: N15Action) -> ToolResult:
         self.kernel.browsers.computer.press_key(
             self.session_id,
-            keys=["alt+Right"],
+            keys=["Alt+Right"],
         )
         await asyncio.sleep(1.5)
         return await self.screenshot()
@@ -326,13 +377,13 @@ class ComputerTool:
 
         self.kernel.browsers.computer.press_key(
             self.session_id,
-            keys=["ctrl+l"],
+            keys=["Ctrl+l"],
         )
         await asyncio.sleep(ACTION_DELAY_S)
 
         self.kernel.browsers.computer.press_key(
             self.session_id,
-            keys=["ctrl+a"],
+            keys=["Ctrl+a"],
         )
         await asyncio.sleep(0.1)
 
@@ -358,7 +409,7 @@ class ComputerTool:
             png_bytes = response.read()
             img = Image.open(BytesIO(png_bytes))
             webp_buf = BytesIO()
-            img.save(webp_buf, "WEBP", quality=80)
+            img.save(webp_buf, "WEBP", quality=WEBP_QUALITY)
             base64_image = base64.b64encode(webp_buf.getvalue()).decode("utf-8")
             return {"base64_image": base64_image}
         except Exception as e:
@@ -375,15 +426,3 @@ class ComputerTool:
             raise ToolError(f"Invalid coordinates: {coords}")
 
         return {"x": int(x), "y": int(y)}
-
-    def _map_key(self, key: str) -> str:
-        def map_part(part: str) -> str:
-            trimmed = part.strip()
-            lower = trimmed.lower()
-            if lower in MODIFIER_MAP:
-                return MODIFIER_MAP[lower]
-            return KEY_MAP.get(trimmed, trimmed)
-
-        if "+" in key:
-            return "+".join(map_part(p) for p in key.split("+"))
-        return map_part(key)

--- a/pkg/templates/python/yutori/tools/computer.py
+++ b/pkg/templates/python/yutori/tools/computer.py
@@ -7,6 +7,8 @@ Screenshots are converted to WebP for better compression across multi-step traje
 @see https://docs.yutori.com/reference/n1-5
 """
 
+from __future__ import annotations
+
 import asyncio
 import base64
 import json
@@ -126,6 +128,13 @@ KEY_MAP: dict[str, str] = {
 def _map_token(token: str) -> str:
     lower = token.strip().lower()
     return KEY_MAP.get(lower, token.strip())
+
+
+def _normalize_url(url: str) -> str:
+    trimmed = url.strip()
+    if "://" in trimmed:
+        return trimmed
+    return f"https://{trimmed}"
 
 
 def _parse_key_expression(expr: str) -> list[str]:
@@ -363,11 +372,12 @@ class ComputerTool:
         url = action.get("url")
         if not url:
             raise ToolError("url is required for goto_url action")
+        target_url = _normalize_url(url)
 
         if self.kiosk_mode:
             response = self.kernel.browsers.playwright.execute(
                 self.session_id,
-                code=f"await page.goto({json.dumps(url)});",
+                code=f"await page.goto({json.dumps(target_url)});",
                 timeout_sec=60,
             )
             if not response.success:
@@ -389,7 +399,7 @@ class ComputerTool:
 
         self.kernel.browsers.computer.type_text(
             self.session_id,
-            text=url,
+            text=target_url,
             delay=TYPING_DELAY_MS,
         )
         await asyncio.sleep(ACTION_DELAY_S)

--- a/pkg/templates/typescript/yutori/README.md
+++ b/pkg/templates/typescript/yutori/README.md
@@ -22,6 +22,18 @@ kernel deploy index.ts --env-file .env
 ## Usage
 
 ```bash
+kernel invoke ts-yutori-cua cua-task --payload '{"query": "Navigate to https://www.yutori.com and list the team member names."}'
+```
+
+Optional payload fields:
+
+- `record_replay` (bool) — capture a video of the session (paid plans only).
+- `kiosk` (bool) — launch the browser without address bar / tabs ([see below](#kiosk-mode)).
+- `user_timezone` (IANA, e.g. `"America/New_York"`) and `user_location` (free text, e.g. `"New York, NY, US"`) — appended to the task message so the model has accurate temporal/locational grounding.
+
+More involved example (Kanban drag-and-drop):
+
+```bash
 kernel invoke ts-yutori-cua cua-task --payload '{"query": "Go to https://www.magnitasks.com, Click the Tasks option in the left-side bar, and drag the 5 items in the To Do and In Progress columns to the Done section of the Kanban board. You are done successfully when the items are dragged to Done. Do not click into the items."}'
 ```
 

--- a/pkg/templates/typescript/yutori/index.ts
+++ b/pkg/templates/typescript/yutori/index.ts
@@ -1,4 +1,5 @@
 import { Kernel, type KernelContext } from '@onkernel/sdk';
+import type OpenAI from 'openai';
 import { samplingLoop } from './loop';
 import { KernelBrowserSession } from './session';
 
@@ -10,6 +11,8 @@ interface QueryInput {
   query: string;
   record_replay?: boolean;
   kiosk?: boolean;
+  user_timezone?: string;
+  user_location?: string;
 }
 
 interface QueryOutput {
@@ -55,6 +58,8 @@ app.action<QueryInput, QueryOutput>(
         viewportWidth: session.viewportWidth,
         viewportHeight: session.viewportHeight,
         kioskMode,
+        userTimezone: payload.user_timezone,
+        userLocation: payload.user_location,
       });
 
       // Extract the result
@@ -75,10 +80,10 @@ app.action<QueryInput, QueryOutput>(
   },
 );
 
-function extractLastAssistantMessage(messages: { role: string; content: string | unknown[] }[]): string {
+function extractLastAssistantMessage(messages: OpenAI.ChatCompletionMessageParam[]): string {
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i];
-    if (msg.role === 'assistant' && typeof msg.content === 'string' && msg.content) {
+    if (msg && msg.role === 'assistant' && typeof msg.content === 'string' && msg.content) {
       return msg.content;
     }
   }

--- a/pkg/templates/typescript/yutori/loop.ts
+++ b/pkg/templates/typescript/yutori/loop.ts
@@ -21,6 +21,8 @@ import { ComputerTool, type N15Action, type ToolResult } from './tools/computer'
 const DISABLED_TOOLS = ['extract_elements', 'find', 'set_element_value', 'execute_js'];
 const TOOL_SET = 'browser_tools_core-20260403';
 
+const NAVIGATOR_COORDINATE_SCALE = 1000;
+
 // Screenshot-trimming defaults mirror Yutori's reference loop:
 // https://github.com/yutori-ai/yutori-sdk-python/blob/main/yutori/navigator/payload.py
 // Trimming is size-triggered — we only drop old screenshots when the payload
@@ -44,9 +46,11 @@ interface SamplingLoopOptions {
   viewportWidth?: number;
   viewportHeight?: number;
   kioskMode?: boolean;
+  userTimezone?: string;
+  userLocation?: string;
 }
 
-interface SamplingLoopResult {
+export interface SamplingLoopResult {
   messages: OpenAI.ChatCompletionMessageParam[];
   finalAnswer?: string;
 }
@@ -58,10 +62,12 @@ export async function samplingLoop({
   kernel,
   sessionId,
   maxCompletionTokens = 4096,
-  maxIterations = 50,
+  maxIterations = 100,
   viewportWidth = 1280,
   viewportHeight = 800,
   kioskMode = false,
+  userTimezone = 'America/Los_Angeles',
+  userLocation = 'San Francisco, CA, US',
 }: SamplingLoopOptions): Promise<SamplingLoopResult> {
   const client = new OpenAI({
     apiKey,
@@ -72,11 +78,16 @@ export async function samplingLoop({
 
   const initialScreenshot = await computerTool.screenshot();
 
+  // Append location/timezone/current-date context to the task — mirrors Yutori's
+  // format_task_with_context helper and helps the model with date-sensitive
+  // judgments. https://github.com/yutori-ai/yutori-sdk-python/blob/main/yutori/navigator/context.py
+  const taskWithContext = formatTaskWithContext(task, userTimezone, userLocation);
+
   const conversationMessages: OpenAI.ChatCompletionMessageParam[] = [
     {
       role: 'user',
       content: [
-        { type: 'text', text: task },
+        { type: 'text', text: taskWithContext },
         ...(initialScreenshot.base64Image
           ? [{
               type: 'image_url' as const,
@@ -129,8 +140,7 @@ export async function samplingLoop({
       throw new Error('No choices in API response');
     }
 
-    const choice = response.choices[0];
-    const assistantMessage = choice.message;
+    const assistantMessage = response.choices[0]?.message;
     if (!assistantMessage) {
       throw new Error('No response from model');
     }
@@ -213,8 +223,41 @@ export async function samplingLoop({
     }
   }
 
-  if (iteration >= maxIterations) {
-    console.log('Max iterations reached');
+  // If the loop exhausted iterations, prompt the model for a final summary so
+  // the caller gets a usable answer instead of empty content. Mirrors Yutori's
+  // format_stop_and_summarize helper.
+  if (iteration >= maxIterations && !finalAnswer) {
+    console.log('Max iterations reached — requesting summary');
+    try {
+      const finalScreenshot = await computerTool.screenshot();
+      conversationMessages.push({
+        role: 'user',
+        content: [
+          { type: 'text', text: formatStopAndSummarize(task) },
+          ...(finalScreenshot.base64Image
+            ? [{
+                type: 'image_url' as const,
+                image_url: { url: `data:image/webp;base64,${finalScreenshot.base64Image}` },
+              }]
+            : []),
+        ],
+      });
+      const { messages: summaryMessages } = trimmedForRequest(conversationMessages);
+      const summaryResponse = await client.chat.completions.create({
+        model,
+        messages: summaryMessages,
+        max_completion_tokens: maxCompletionTokens,
+        temperature: 0.3,
+        ...({ tool_set: TOOL_SET, disable_tools: DISABLED_TOOLS } satisfies YutoriExtras),
+      });
+      const summary = summaryResponse.choices[0]?.message;
+      if (summary) {
+        conversationMessages.push(summary);
+        finalAnswer = summary.content || undefined;
+      }
+    } catch (error) {
+      console.error('Stop-and-summarize call failed:', error);
+    }
   }
 
   return {
@@ -223,24 +266,88 @@ export async function samplingLoop({
   };
 }
 
+function formatTaskWithContext(task: string, userTimezone: string, userLocation: string): string {
+  let tzLabel = userTimezone;
+  let now: Date;
+  let timeFormatter: Intl.DateTimeFormat;
+  let dateFormatter: Intl.DateTimeFormat;
+  let weekdayFormatter: Intl.DateTimeFormat;
+  try {
+    now = new Date();
+    timeFormatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: userTimezone,
+      hour12: false,
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      timeZoneName: 'short',
+    });
+    dateFormatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: userTimezone,
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+    weekdayFormatter = new Intl.DateTimeFormat('en-US', { timeZone: userTimezone, weekday: 'long' });
+  } catch {
+    tzLabel = 'UTC';
+    now = new Date();
+    timeFormatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: 'UTC',
+      hour12: false,
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      timeZoneName: 'short',
+    });
+    dateFormatter = new Intl.DateTimeFormat('en-US', { timeZone: 'UTC', year: 'numeric', month: 'long', day: 'numeric' });
+    weekdayFormatter = new Intl.DateTimeFormat('en-US', { timeZone: 'UTC', weekday: 'long' });
+  }
+
+  const context = [
+    `User's location: ${userLocation}`,
+    `User's timezone: ${tzLabel}`,
+    `Current Date: ${dateFormatter.format(now)}`,
+    `Current Time: ${timeFormatter.format(now)}`,
+    `Today is: ${weekdayFormatter.format(now)}`,
+  ].join('\n');
+
+  return `${task}\n\n${context}`;
+}
+
+function formatStopAndSummarize(task: string): string {
+  return (
+    `Stop here. ` +
+    `Summarize your current progress and list in detail all the findings ` +
+    `relevant to the given task:\n${task}\n` +
+    `Provide URLs for all relevant results you find and return them in your response. ` +
+    `If there is no specific URL for a result, ` +
+    `cite the page URL that the information was found on.`
+  );
+}
+
 function scaleCoordinates(action: N15Action, viewportWidth: number, viewportHeight: number): N15Action {
   const scaled = { ...action };
 
   if (scaled.coordinates) {
-    scaled.coordinates = [
-      Math.round((scaled.coordinates[0] / 1000) * viewportWidth),
-      Math.round((scaled.coordinates[1] / 1000) * viewportHeight),
-    ];
+    scaled.coordinates = denormalize(scaled.coordinates, viewportWidth, viewportHeight);
   }
 
   if (scaled.start_coordinates) {
-    scaled.start_coordinates = [
-      Math.round((scaled.start_coordinates[0] / 1000) * viewportWidth),
-      Math.round((scaled.start_coordinates[1] / 1000) * viewportHeight),
-    ];
+    scaled.start_coordinates = denormalize(scaled.start_coordinates, viewportWidth, viewportHeight);
   }
 
   return scaled;
+}
+
+// Map [0, 1000] coordinates into viewport pixels and clamp to [0, dim-1] so a
+// boundary value like 1000 doesn't land one pixel outside the viewport.
+function denormalize(coords: [number, number], width: number, height: number): [number, number] {
+  const rawX = Math.round((coords[0] / NAVIGATOR_COORDINATE_SCALE) * width);
+  const rawY = Math.round((coords[1] / NAVIGATOR_COORDINATE_SCALE) * height);
+  const x = Math.max(0, Math.min(width - 1, rawX));
+  const y = Math.max(0, Math.min(height - 1, rawY));
+  return [x, y];
 }
 
 interface ImagePart {
@@ -300,7 +407,7 @@ function trimmedForRequest(
 
   const imageIndices: number[] = [];
   for (let i = 0; i < trimmed.length; i++) {
-    if (messageHasImage(trimmed[i])) imageIndices.push(i);
+    if (messageHasImage(trimmed[i]!)) imageIndices.push(i);
   }
   if (imageIndices.length === 0) return { messages: trimmed, removed: 0 };
 
@@ -311,7 +418,7 @@ function trimmedForRequest(
   for (const idx of imageIndices) {
     if (size <= MAX_REQUEST_BYTES) break;
     if (protectedIdx.has(idx)) continue;
-    if (stripOneImage(trimmed[idx])) {
+    if (stripOneImage(trimmed[idx]!)) {
       removed++;
       size = estimateSize(trimmed);
     }
@@ -319,11 +426,11 @@ function trimmedForRequest(
 
   // If still over, strip from the protected window too — but always keep the latest.
   if (size > MAX_REQUEST_BYTES) {
-    const lastIdx = imageIndices[imageIndices.length - 1];
+    const lastIdx = imageIndices[imageIndices.length - 1]!;
     for (const idx of imageIndices) {
       if (size <= MAX_REQUEST_BYTES) break;
       if (idx === lastIdx) continue;
-      if (stripOneImage(trimmed[idx])) {
+      if (stripOneImage(trimmed[idx]!)) {
         removed++;
         size = estimateSize(trimmed);
       }

--- a/pkg/templates/typescript/yutori/loop.ts
+++ b/pkg/templates/typescript/yutori/loop.ts
@@ -267,42 +267,23 @@ export async function samplingLoop({
 }
 
 function formatTaskWithContext(task: string, userTimezone: string, userLocation: string): string {
-  let tzLabel = userTimezone;
-  let now: Date;
-  let timeFormatter: Intl.DateTimeFormat;
-  let dateFormatter: Intl.DateTimeFormat;
-  let weekdayFormatter: Intl.DateTimeFormat;
-  try {
-    now = new Date();
-    timeFormatter = new Intl.DateTimeFormat('en-US', {
-      timeZone: userTimezone,
-      hour12: false,
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-      timeZoneName: 'short',
-    });
-    dateFormatter = new Intl.DateTimeFormat('en-US', {
-      timeZone: userTimezone,
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-    });
-    weekdayFormatter = new Intl.DateTimeFormat('en-US', { timeZone: userTimezone, weekday: 'long' });
-  } catch {
-    tzLabel = 'UTC';
-    now = new Date();
-    timeFormatter = new Intl.DateTimeFormat('en-US', {
-      timeZone: 'UTC',
-      hour12: false,
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-      timeZoneName: 'short',
-    });
-    dateFormatter = new Intl.DateTimeFormat('en-US', { timeZone: 'UTC', year: 'numeric', month: 'long', day: 'numeric' });
-    weekdayFormatter = new Intl.DateTimeFormat('en-US', { timeZone: 'UTC', weekday: 'long' });
-  }
+  const now = new Date();
+  const tzLabel = resolveTimezone(userTimezone);
+  const timeFormatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: tzLabel,
+    hour12: false,
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    timeZoneName: 'short',
+  });
+  const dateFormatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: tzLabel,
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+  const weekdayFormatter = new Intl.DateTimeFormat('en-US', { timeZone: tzLabel, weekday: 'long' });
 
   const context = [
     `User's location: ${userLocation}`,
@@ -313,6 +294,18 @@ function formatTaskWithContext(task: string, userTimezone: string, userLocation:
   ].join('\n');
 
   return `${task}\n\n${context}`;
+}
+
+function resolveTimezone(userTimezone: string): string {
+  for (const timeZone of [userTimezone, 'America/Los_Angeles', 'UTC']) {
+    try {
+      new Intl.DateTimeFormat('en-US', { timeZone }).format(new Date());
+      return timeZone;
+    } catch {
+      // Try the next fallback.
+    }
+  }
+  return 'UTC';
 }
 
 function formatStopAndSummarize(task: string): string {

--- a/pkg/templates/typescript/yutori/tools/computer.ts
+++ b/pkg/templates/typescript/yutori/tools/computer.ts
@@ -15,6 +15,18 @@ const TYPING_DELAY_MS = 12;
 const SCREENSHOT_DELAY_MS = 150;
 const ACTION_DELAY_MS = 300;
 
+// n1.5 scroll `amount` is in "wheel units" where 1 unit ≈ 10% of the viewport
+// height (~80px at 800px tall). Kernel's `delta_y` is a wheel-event repeat
+// count where each tick is much smaller in practice, so we multiply.
+const SCROLL_NOTCHES_PER_AMOUNT = 4;
+
+// WebP quality for screenshots. Kernel returns PNGs, which are crisp and
+// tolerate aggressive WebP compression with no visible degradation — matches
+// Yutori SDK's DEFAULT_WEBP_QUALITY_FOR_PNG=30 (yutori-sdk-python/yutori/
+// navigator/images.py). Lower values cut payload size substantially on long
+// multi-step trajectories.
+const WEBP_QUALITY = 30;
+
 export interface ToolResult {
   base64Image?: string;
   output?: string;
@@ -61,43 +73,80 @@ export interface N15Action {
   url?: string;
 }
 
+// n1.5 emits lowercase key names (e.g. `enter`, `ctrl+c`, `down down down enter`).
+// Kernel's press_key expects XKeysym names (e.g. `Return`, `Ctrl`, `Page_Up`).
+// This map covers every key Yutori documents at
+// https://docs.yutori.com/reference/n1-5#key-space — keys not in the map pass
+// through unchanged (printable characters like `a`, `1`, `,` are already XKeysym).
+//
+// Sister implementation (Playwright target instead of XKeysym):
+// https://github.com/yutori-ai/yutori-sdk-python/blob/main/yutori/navigator/keys.py
 const KEY_MAP: Record<string, string> = {
-  'Enter': 'Return',
-  'Escape': 'Escape',
-  'Backspace': 'BackSpace',
-  'Tab': 'Tab',
-  'Delete': 'Delete',
-  'ArrowUp': 'Up',
-  'ArrowDown': 'Down',
-  'ArrowLeft': 'Left',
-  'ArrowRight': 'Right',
-  'Home': 'Home',
-  'End': 'End',
-  'PageUp': 'Page_Up',
-  'PageDown': 'Page_Down',
-  'F1': 'F1',
-  'F2': 'F2',
-  'F3': 'F3',
-  'F4': 'F4',
-  'F5': 'F5',
-  'F6': 'F6',
-  'F7': 'F7',
-  'F8': 'F8',
-  'F9': 'F9',
-  'F10': 'F10',
-  'F11': 'F11',
-  'F12': 'F12',
+  // Modifiers
+  ctrl: 'Ctrl',
+  control: 'Ctrl',
+  shift: 'Shift',
+  alt: 'Alt',
+  meta: 'Super_L',
+  command: 'Super_L',
+  cmd: 'Super_L',
+  super: 'Super_L',
+  option: 'Alt',
+  // Enter
+  enter: 'Return',
+  return: 'Return',
+  // Navigation
+  tab: 'Tab',
+  backspace: 'BackSpace',
+  delete: 'Delete',
+  escape: 'Escape',
+  esc: 'Escape',
+  space: 'space',
+  // Arrows
+  up: 'Up',
+  down: 'Down',
+  left: 'Left',
+  right: 'Right',
+  arrowup: 'Up',
+  arrowdown: 'Down',
+  arrowleft: 'Left',
+  arrowright: 'Right',
+  // Page nav
+  home: 'Home',
+  end: 'End',
+  pageup: 'Page_Up',
+  pagedown: 'Page_Down',
+  // Function keys
+  f1: 'F1', f2: 'F2', f3: 'F3', f4: 'F4', f5: 'F5', f6: 'F6',
+  f7: 'F7', f8: 'F8', f9: 'F9', f10: 'F10', f11: 'F11', f12: 'F12',
+  // Locks / special
+  capslock: 'Caps_Lock',
+  numlock: 'Num_Lock',
+  scrolllock: 'Scroll_Lock',
+  insert: 'Insert',
+  pause: 'Pause',
+  printscreen: 'Print',
 };
 
-const MODIFIER_MAP: Record<string, string> = {
-  'control': 'ctrl',
-  'ctrl': 'ctrl',
-  'alt': 'alt',
-  'shift': 'shift',
-  'meta': 'super',
-  'command': 'super',
-  'cmd': 'super',
-};
+function mapToken(token: string): string {
+  const lower = token.trim().toLowerCase();
+  return KEY_MAP[lower] ?? token.trim();
+}
+
+// Parse an n1.5 key expression into one Kernel combo string per sequential
+// press. Spaces separate sequential presses; `+` separates simultaneous tokens
+// within a press. Examples:
+//   "enter"             -> ["Return"]
+//   "ctrl+c"            -> ["Ctrl+c"]
+//   "down down enter"   -> ["Down", "Down", "Return"]
+//   "ctrl+shift+t"      -> ["Ctrl+Shift+t"]
+function parseKeyExpression(expr: string): string[] {
+  return expr
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((combo) => combo.split('+').map(mapToken).join('+'));
+}
 
 export class ComputerTool {
   private kernel: Kernel;
@@ -161,7 +210,7 @@ export class ComputerTool {
 
   private async handleClick(action: N15Action, button: 'left' | 'right' | 'middle', numClicks: number): Promise<ToolResult> {
     const coords = this.getCoordinates(action.coordinates);
-    const holdKeys = action.modifier ? [this.mapKey(action.modifier)] : undefined;
+    const holdKeys = action.modifier ? [mapToken(action.modifier)] : undefined;
 
     await this.kernel.browsers.computer.clickMouse(this.sessionId, {
       x: coords.x,
@@ -205,31 +254,34 @@ export class ComputerTool {
   private async handleScroll(action: N15Action): Promise<ToolResult> {
     const coords = this.getCoordinates(action.coordinates);
     const direction = action.direction;
-    const notches = Math.max(action.amount ?? 3, 1);
+    const amount = Math.max(action.amount ?? 3, 1);
 
     if (!direction || !['up', 'down', 'left', 'right'].includes(direction)) {
       throw new ToolError(`Invalid scroll direction: ${direction}`);
     }
+
+    // Yutori 1 unit ≈ 10% of viewport height; scale into Kernel wheel-event ticks.
+    const ticks = amount * SCROLL_NOTCHES_PER_AMOUNT;
 
     let delta_x = 0;
     let delta_y = 0;
 
     switch (direction) {
       case 'up':
-        delta_y = -notches;
+        delta_y = -ticks;
         break;
       case 'down':
-        delta_y = notches;
+        delta_y = ticks;
         break;
       case 'left':
-        delta_x = -notches;
+        delta_x = -ticks;
         break;
       case 'right':
-        delta_x = notches;
+        delta_x = ticks;
         break;
     }
 
-    const holdKeys = action.modifier ? [this.mapKey(action.modifier)] : undefined;
+    const holdKeys = action.modifier ? [mapToken(action.modifier)] : undefined;
 
     await this.kernel.browsers.computer.scroll(this.sessionId, {
       x: coords.x,
@@ -243,7 +295,7 @@ export class ComputerTool {
     const screenshotResult = await this.screenshot();
     return {
       ...screenshotResult,
-      output: `Scrolled ${notches} wheel unit(s) ${direction}.`,
+      output: `Scrolled ${amount} unit(s) ${direction}.`,
     };
   }
 
@@ -268,11 +320,12 @@ export class ComputerTool {
       throw new ToolError('key is required for key_press action');
     }
 
-    const mappedKey = this.mapKey(key);
-
-    await this.kernel.browsers.computer.pressKey(this.sessionId, {
-      keys: [mappedKey],
-    });
+    // n1.5 supports sequential presses ("down down down enter") — issue each
+    // combo as its own pressKey so they're seen as separate keystrokes.
+    const combos = parseKeyExpression(key);
+    for (const combo of combos) {
+      await this.kernel.browsers.computer.pressKey(this.sessionId, { keys: [combo] });
+    }
 
     await this.sleep(SCREENSHOT_DELAY_MS);
     return this.screenshot();
@@ -284,14 +337,16 @@ export class ComputerTool {
       throw new ToolError('key is required for hold_key action');
     }
 
-    const mappedKey = this.mapKey(key);
     // Yutori emits `duration` in seconds; Kernel SDK's pressKey takes ms.
     const durationMs = action.duration && action.duration > 0 ? Math.round(action.duration * 1000) : 1000;
 
-    await this.kernel.browsers.computer.pressKey(this.sessionId, {
-      keys: [mappedKey],
-      duration: durationMs,
-    });
+    const combos = parseKeyExpression(key);
+    for (const combo of combos) {
+      await this.kernel.browsers.computer.pressKey(this.sessionId, {
+        keys: [combo],
+        duration: durationMs,
+      });
+    }
 
     await this.sleep(SCREENSHOT_DELAY_MS);
     return this.screenshot();
@@ -328,7 +383,7 @@ export class ComputerTool {
 
   private async handleGoBack(): Promise<ToolResult> {
     await this.kernel.browsers.computer.pressKey(this.sessionId, {
-      keys: ['alt+Left'],
+      keys: ['Alt+Left'],
     });
 
     await this.sleep(1500);
@@ -337,7 +392,7 @@ export class ComputerTool {
 
   private async handleGoForward(): Promise<ToolResult> {
     await this.kernel.browsers.computer.pressKey(this.sessionId, {
-      keys: ['alt+Right'],
+      keys: ['Alt+Right'],
     });
 
     await this.sleep(1500);
@@ -363,12 +418,12 @@ export class ComputerTool {
     }
 
     await this.kernel.browsers.computer.pressKey(this.sessionId, {
-      keys: ['ctrl+l'],
+      keys: ['Ctrl+l'],
     });
     await this.sleep(ACTION_DELAY_MS);
 
     await this.kernel.browsers.computer.pressKey(this.sessionId, {
-      keys: ['ctrl+a'],
+      keys: ['Ctrl+a'],
     });
     await this.sleep(100);
 
@@ -392,7 +447,7 @@ export class ComputerTool {
       const blob = await response.blob();
       const arrayBuffer = await blob.arrayBuffer();
       const pngBuffer = Buffer.from(arrayBuffer);
-      const webpBuffer = await sharp(pngBuffer).webp({ quality: 80 }).toBuffer();
+      const webpBuffer = await sharp(pngBuffer).webp({ quality: WEBP_QUALITY }).toBuffer();
 
       return {
         base64Image: webpBuffer.toString('base64'),
@@ -404,7 +459,7 @@ export class ComputerTool {
 
   private getCoordinates(coords?: [number, number]): { x: number; y: number } {
     if (!coords || coords.length !== 2) {
-      return { x: this.width / 2, y: this.height / 2 };
+      return { x: Math.floor(this.width / 2), y: Math.floor(this.height / 2) };
     }
 
     const [x, y] = coords;
@@ -415,23 +470,7 @@ export class ComputerTool {
     return { x, y };
   }
 
-  private mapKey(key: string): string {
-    const mapPart = (part: string): string => {
-      const trimmed = part.trim();
-      const lower = trimmed.toLowerCase();
-      if (MODIFIER_MAP[lower]) {
-        return MODIFIER_MAP[lower];
-      }
-      return KEY_MAP[trimmed] || trimmed;
-    };
-
-    if (key.includes('+')) {
-      return key.split('+').map(mapPart).join('+');
-    }
-    return mapPart(key);
-  }
-
   private sleep(ms: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, ms));
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 }

--- a/pkg/templates/typescript/yutori/tools/computer.ts
+++ b/pkg/templates/typescript/yutori/tools/computer.ts
@@ -133,6 +133,11 @@ function mapToken(token: string): string {
   return KEY_MAP[lower] ?? token.trim();
 }
 
+function normalizeUrl(url: string): string {
+  const trimmed = url.trim();
+  return trimmed.includes('://') ? trimmed : `https://${trimmed}`;
+}
+
 // Parse an n1.5 key expression into one Kernel combo string per sequential
 // press. Spaces separate sequential presses; `+` separates simultaneous tokens
 // within a press. Examples:
@@ -404,10 +409,11 @@ export class ComputerTool {
     if (!url) {
       throw new ToolError('url is required for goto_url action');
     }
+    const targetUrl = normalizeUrl(url);
 
     if (this.kioskMode) {
       const response = await this.kernel.browsers.playwright.execute(this.sessionId, {
-        code: `await page.goto(${JSON.stringify(url)});`,
+        code: `await page.goto(${JSON.stringify(targetUrl)});`,
         timeout_sec: 60,
       });
       if (!response.success) {
@@ -428,7 +434,7 @@ export class ComputerTool {
     await this.sleep(100);
 
     await this.kernel.browsers.computer.typeText(this.sessionId, {
-      text: url,
+      text: targetUrl,
       delay: TYPING_DELAY_MS,
     });
     await this.sleep(ACTION_DELAY_MS);

--- a/pkg/templates/typescript/yutori/tsconfig.json
+++ b/pkg/templates/typescript/yutori/tsconfig.json
@@ -1,9 +1,24 @@
 {
-  "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": "."
+    "lib": ["ESNext", "DOM"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
   },
-  "include": ["./**/*.ts"],
+  "include": ["./**/*.ts", "./**/*.tsx"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

PR #159 did the n1 → n1.5 model upgrade, but a few runtime bugs slipped through and the template never fully aligned with the public Yutori reference SDK. This PR fixes both, in both the TS and Python templates.

Implementation cross-checked against the public [yutori-ai/yutori-sdk-python](https://github.com/yutori-ai/yutori-sdk-python) reference (`yutori/navigator/*`).

### Runtime / correctness bugs

- **Key handling rewritten.** n1.5 emits **lowercase** key names (`enter`, `up`, `pageup`) and supports **sequential presses** (`down down down enter` — see [Key Space](https://docs.yutori.com/reference/n1-5#key-space)). The previous `KEY_MAP` was keyed on PascalCase Playwright-style names so it never matched, and the handler sent the entire space-separated expression as a single key. Replaced with a **lowercase → XKeysym** map (matching the names Kernel's `press_key` accepts — `Return`, `Page_Up`, `Ctrl`, etc., per `cmd/browsers_test.go:1512`) and a `parseKeyExpression` / `_parse_key_expression` that issues one `press_key` call per sequential combo. Applies to `key_press`, `hold_key`, click `modifier`, and scroll `modifier`.
- **Coordinates now clamped to [0, dim-1]** after denormalizing from the n1.5 1000×1000 space. A boundary value of `1000` previously mapped to pixel `1280` on a 1280×800 viewport — one pixel outside the valid range. Matches the public SDK's `denormalize_coordinates` default clamp.
- **TS template now type-checks cleanly.** The old `tsconfig.json` `extends`ed `../tsconfig.base.json` (which `kernel create` doesn't copy), `index.ts:61` had a `ChatCompletionMessageParam[]` signature mismatch, and `import sharp from 'sharp'` needed `esModuleInterop`. Inlined the full tsconfig like every other TS template, fixed the function signature, and added `esModuleInterop: true`. Verified with `npx tsc --noEmit` on a fresh scaffold (previously produced 12 errors).
- **Python `pyproject.toml`** description was still `"n1 Computer Use"` → `"n1.5 Computer Use"`.

### Alignment with the public reference SDK

- **WebP quality 80 → 30** for screenshots. Kernel `capture_screenshot` returns PNGs; the public SDK's `DEFAULT_WEBP_QUALITY_FOR_PNG = 30` ([images.py](https://github.com/yutori-ai/yutori-sdk-python/blob/main/yutori/navigator/images.py)) — lossless PNG sources tolerate aggressive WebP compression with no visible degradation, and the payload savings matter on long multi-step trajectories.
- **`formatTaskWithContext` / `_format_task_with_context`** appends location, timezone, current date/time, and weekday to the initial task. Mirrors [`format_task_with_context`](https://github.com/yutori-ai/yutori-sdk-python/blob/main/yutori/navigator/context.py). Threaded through new optional `user_timezone` / `user_location` payload fields.
- **`formatStopAndSummarize` / `_format_stop_and_summarize`**: when the loop hits `maxIterations` without a final answer, one extra screenshot + summary call so callers get a usable result instead of empty content. Mirrors the SDK's reference loop behavior.
- **Scroll amount scaling**: Kernel's `delta_y` is wheel-event repeat count (not pixels), so the previous 1:1 forwarding produced very small scrolls. Now multiplies by `SCROLL_NOTCHES_PER_AMOUNT = 4`, closer to Yutori's documented "1 unit ≈ 10% of viewport height".
- **`maxIterations` 50 → 100** to match the public SDK example default.

### Docs / scaffold

- README headline example now matches the canonical "list team member names from yutori.com" task from the public docs. The magnitasks Kanban demo is kept below as an advanced example. README also documents the new optional payload fields.
- `pkg/create/templates.go` `InvokeCommand` for both TS and Python uses the same canonical example, so the `kernel create` next-steps hint matches the README.

## Test plan

- [x] `make build && make test` pass; `go vet ./...` clean.
- [x] Scaffolded a fresh TS app from the updated template; `npx tsc --noEmit` passes (previously failed: missing `tsconfig.base`, type-mismatch in `index.ts:61`, sharp default import).
- [x] `kernel deploy` from the fresh scaffold deploys with **no** TypeScript warnings (previously deploy logs included `Cannot read file '/boot-node/tsconfig.base.json'` and the `ChatCompletionMessageParam[]` error).
- [x] `kernel invoke` runs end-to-end against `https://www.yutori.com` / "list team member names" — agent navigates to the team page and identifies team members. (Note: yutori.com's parallax team UI is genuinely tricky for any CUA; the iteration count is a UI artifact, not a template regression. n1.5 emits `mouse_move` actions to trigger the hover-reveal cards, which the new code handles.)
- [x] *Reviewer item*: ideally also test `key_press` Enter, sequential presses (`down down enter`), `pageup`/`pagedown`, and shift-click `modifier` to exercise the new key map paths end-to-end. I couldn't reach a trajectory that emitted those during the smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates core Yutori agent loop/tool translation logic (keys, coordinates, scrolling, iteration behavior), which can change automation behavior and failure modes, but is limited to templates and not security-sensitive code.
> 
> **Overview**
> Improves the Yutori n1.5 computer-use templates (TS + Python) to better match Yutori’s reference recommendations and fix several runtime/correctness issues.
> 
> The sampling loops now **add timezone/location/date context** to the initial task, **raise `maxIterations` to 100**, and if the loop times out without a final answer they perform a **stop-and-summarize** follow-up call so invocations return a usable result.
> 
> The computer tools were adjusted for n1.5 behavior: **lowercase/sequential key expressions are parsed and mapped to Kernel keysyms**, normalized coordinates are **clamped** when denormalized to viewport pixels, scroll `amount` is **scaled** to Kernel wheel ticks, screenshot WebP quality is reduced for smaller payloads, and `goto_url` now normalizes missing schemes.
> 
> Docs and scaffolding were updated: README examples and `kernel create` invoke hints now use the `yutori.com` “team member names” task, new optional payload fields (`user_timezone`, `user_location`) are documented/exposed, Python metadata is corrected to n1.5, and the TS template inlines a standalone `tsconfig.json` and fixes type issues (including `esModuleInterop`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24ae144d3ba3b2c97ff413f421e8a4d78ae796b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->