### PR TITLE
Support OAuth URL overrides

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/kernel/cli/pkg/auth"
+	"github.com/kernel/cli/pkg/util"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 	"github.com/zalando/go-keyring"
@@ -85,6 +86,7 @@ func runAuth(cmd *cobra.Command, args []string) error {
 		// Check if API key is being used as fallback
 		if apiKey := os.Getenv("KERNEL_API_KEY"); apiKey != "" {
 			pterm.Info.Println("Authentication method: API Key")
+			pterm.Info.Printf("API URL: %s\n", util.GetBaseURL())
 			if len(apiKey) >= 12 {
 				pterm.Info.Printf("API Key: %s...%s\n", apiKey[:8], apiKey[len(apiKey)-4:])
 			} else {
@@ -94,6 +96,8 @@ func runAuth(cmd *cobra.Command, args []string) error {
 		}
 
 		pterm.Info.Println("No active session found - not authenticated")
+		pterm.Info.Printf("API URL: %s\n", util.GetBaseURL())
+		pterm.Info.Printf("Auth URL: %s\n", auth.CurrentAuthBaseURL())
 		pterm.Info.Println("Run 'kernel login' to authenticate with OAuth")
 		pterm.Info.Println("Or set KERNEL_API_KEY environment variable")
 		return nil
@@ -101,6 +105,9 @@ func runAuth(cmd *cobra.Command, args []string) error {
 
 	// Display OAuth authentication status
 	pterm.Success.Println("✓ Authenticated with OAuth")
+	pterm.Info.Printf("API URL: %s\n", util.GetBaseURL())
+	pterm.Info.Printf("Auth URL: %s\n", tokenAuthBaseURLForDisplay(tokens))
+	pterm.Info.Printf("OAuth client ID: %s\n", maskClientID(tokenOAuthClientIDForDisplay(tokens)))
 
 	// Extract info from JWT token
 	if claims, err := parseJWT(tokens.AccessToken); err == nil && claims != nil {
@@ -136,4 +143,25 @@ func runAuth(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func tokenAuthBaseURLForDisplay(tokens *auth.TokenStorage) string {
+	if tokens.AuthBaseURL != "" {
+		return tokens.AuthBaseURL
+	}
+	return auth.DefaultAuthBaseURL
+}
+
+func tokenOAuthClientIDForDisplay(tokens *auth.TokenStorage) string {
+	if tokens.OAuthClientID != "" {
+		return tokens.OAuthClientID
+	}
+	return auth.DefaultClientID
+}
+
+func maskClientID(clientID string) string {
+	if len(clientID) <= 8 {
+		return clientID
+	}
+	return clientID[:4] + "..." + clientID[len(clientID)-4:]
 }

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 
 	"github.com/kernel/cli/pkg/auth"
+	"github.com/kernel/cli/pkg/util"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
@@ -49,6 +50,8 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create OAuth configuration: %w", err)
 	}
+	pterm.Info.Printf("API URL: %s\n", util.GetBaseURL())
+	pterm.Info.Printf("Auth URL: %s\n", oauthConfig.AuthBaseURL)
 
 	pterm.Debug.Printf("Starting local callback server on %s\n", oauthConfig.Config.RedirectURL)
 

--- a/pkg/auth/oauth.go
+++ b/pkg/auth/oauth.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -25,23 +26,11 @@ var successHTML string
 
 const (
 	// MCP Server OAuth endpoints (which proxy to Clerk)
-	// Production
-	AuthURL  = "https://auth.onkernel.com/authorize"
-	TokenURL = "https://auth.onkernel.com/token"
-	
-	// Staging
-	// AuthURL  = "https://auth.dev.onkernel.com/authorize"
-	// TokenURL = "https://auth.dev.onkernel.com/token"
-	
-	// Local
-	// AuthURL  = "http://localhost:3002/authorize"
-	// TokenURL = "http://localhost:3002/token"
+	DefaultAuthBaseURL = "https://auth.onkernel.com"
 
 	// OAuth client configuration
-	ClientID    = "hmFrJn9hKDV2N02M" // Prod Kernel CLI OAuth Client ID
-	// ClientID    = "gkUVbm11p6EqKd7r" // Staging Kernel CLI OAuth Client ID
-	// ClientID    = "J7i8BKwyFBoyPQN3" // Local Kernel CLI OAuth Client ID
-	RedirectURI = "http://localhost"
+	DefaultClientID = "hmFrJn9hKDV2N02M"
+	RedirectURI     = "http://localhost"
 
 	// OAuth scopes - openid for the MCP server flow
 	DefaultScope = "openid email"
@@ -49,9 +38,11 @@ const (
 
 // OAuthConfig represents the OAuth2 configuration
 type OAuthConfig struct {
-	Config   *oauth2.Config
-	Verifier string
-	State    string
+	Config        *oauth2.Config
+	Verifier      string
+	State         string
+	AuthBaseURL   string
+	OAuthClientID string
 }
 
 // TokenResponse represents the OAuth token response
@@ -67,6 +58,52 @@ type TokenResponse struct {
 type AuthResult struct {
 	Code  string `json:"code"`
 	OrgID string `json:"org_id,omitempty"`
+}
+
+// CurrentAuthBaseURL returns the OAuth server base URL for new login flows.
+func CurrentAuthBaseURL() string {
+	return authBaseURLFromEnv()
+}
+
+// CurrentOAuthClientID returns the OAuth client ID for new login flows.
+func CurrentOAuthClientID() string {
+	if clientID := strings.TrimSpace(os.Getenv("KERNEL_OAUTH_CLIENT_ID")); clientID != "" {
+		return clientID
+	}
+	return DefaultClientID
+}
+
+func authBaseURLFromEnv() string {
+	return normalizeAuthBaseURL(os.Getenv("KERNEL_AUTH_BASE_URL"))
+}
+
+func normalizeAuthBaseURL(raw string) string {
+	if baseURL := strings.TrimRight(strings.TrimSpace(raw), "/"); baseURL != "" {
+		return baseURL
+	}
+	return DefaultAuthBaseURL
+}
+
+func authorizeURL(authBaseURL string) string {
+	return strings.TrimRight(authBaseURL, "/") + "/authorize"
+}
+
+func tokenURL(authBaseURL string) string {
+	return strings.TrimRight(authBaseURL, "/") + "/token"
+}
+
+func tokenAuthBaseURL(tokens *TokenStorage) string {
+	if tokens != nil && tokens.AuthBaseURL != "" {
+		return normalizeAuthBaseURL(tokens.AuthBaseURL)
+	}
+	return DefaultAuthBaseURL
+}
+
+func tokenOAuthClientID(tokens *TokenStorage) string {
+	if tokens != nil && tokens.OAuthClientID != "" {
+		return tokens.OAuthClientID
+	}
+	return DefaultClientID
 }
 
 // NewOAuthConfig creates a new OAuth configuration with PKCE
@@ -96,22 +133,26 @@ func NewOAuthConfig() (*OAuthConfig, error) {
 	// Try to find an available port from our allowed range
 	// Note: We'll get the actual port later when starting the server to avoid race conditions
 	redirectURI := fmt.Sprintf("%s:0/callback", RedirectURI)
+	authBaseURL := CurrentAuthBaseURL()
+	clientID := CurrentOAuthClientID()
 
 	config := &oauth2.Config{
-		ClientID:    ClientID,
+		ClientID:    clientID,
 		RedirectURL: redirectURI,
 		Scopes:      strings.Split(DefaultScope, " "),
 		Endpoint: oauth2.Endpoint{
-			AuthURL:   AuthURL,
-			TokenURL:  TokenURL,
+			AuthURL:   authorizeURL(authBaseURL),
+			TokenURL:  tokenURL(authBaseURL),
 			AuthStyle: oauth2.AuthStyleInParams,
 		},
 	}
 
 	return &OAuthConfig{
-		Config:   config,
-		Verifier: verifier,
-		State:    state, // Store the encoded state for OAuth URL
+		Config:        config,
+		Verifier:      verifier,
+		State:         state, // Store the encoded state for OAuth URL
+		AuthBaseURL:   authBaseURL,
+		OAuthClientID: clientID,
 	}, nil
 }
 
@@ -265,10 +306,12 @@ func (oc *OAuthConfig) exchangeCodeForTokens(ctx context.Context, code, orgID st
 	}
 
 	return &TokenStorage{
-		AccessToken:  token.AccessToken,
-		RefreshToken: token.RefreshToken,
-		ExpiresAt:    token.Expiry,
-		OrgID:        orgID,
+		AccessToken:   token.AccessToken,
+		RefreshToken:  token.RefreshToken,
+		ExpiresAt:     token.Expiry,
+		OrgID:         orgID,
+		AuthBaseURL:   oc.AuthBaseURL,
+		OAuthClientID: oc.OAuthClientID,
 	}, nil
 }
 
@@ -281,14 +324,14 @@ func RefreshTokens(ctx context.Context, tokens *TokenStorage) (*TokenStorage, er
 	values := url.Values{}
 	values.Set("grant_type", "refresh_token")
 	values.Set("refresh_token", tokens.RefreshToken)
-	values.Set("client_id", ClientID)
+	values.Set("client_id", tokenOAuthClientID(tokens))
 	values.Set("scope", DefaultScope)
 	if tokens.OrgID != "" {
 		values.Set("org_id", tokens.OrgID)
 	}
 
 	// Make the token request manually to ensure client_id is included
-	req, err := http.NewRequestWithContext(ctx, "POST", TokenURL, strings.NewReader(values.Encode()))
+	req, err := http.NewRequestWithContext(ctx, "POST", tokenURL(tokenAuthBaseURL(tokens)), strings.NewReader(values.Encode()))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create refresh request: %w", err)
 	}
@@ -328,10 +371,12 @@ func RefreshTokens(ctx context.Context, tokens *TokenStorage) (*TokenStorage, er
 	newToken = newToken.WithExtra(tokenResponse)
 
 	return &TokenStorage{
-		AccessToken:  newToken.AccessToken,
-		RefreshToken: newToken.RefreshToken,
-		ExpiresAt:    newToken.Expiry,
-		OrgID:        tokens.OrgID,
+		AccessToken:   newToken.AccessToken,
+		RefreshToken:  newToken.RefreshToken,
+		ExpiresAt:     newToken.Expiry,
+		OrgID:         tokens.OrgID,
+		AuthBaseURL:   tokenAuthBaseURL(tokens),
+		OAuthClientID: tokenOAuthClientID(tokens),
 	}, nil
 }
 

--- a/pkg/auth/oauth_test.go
+++ b/pkg/auth/oauth_test.go
@@ -1,0 +1,57 @@
+package auth
+
+import "testing"
+
+func TestNewOAuthConfigUsesAuthOverrides(t *testing.T) {
+	t.Setenv("KERNEL_AUTH_BASE_URL", "https://auth.dev.onkernel.com/")
+	t.Setenv("KERNEL_OAUTH_CLIENT_ID", "staging-client-id")
+
+	cfg, err := NewOAuthConfig()
+	if err != nil {
+		t.Fatalf("NewOAuthConfig() error = %v", err)
+	}
+
+	if got, want := cfg.AuthBaseURL, "https://auth.dev.onkernel.com"; got != want {
+		t.Fatalf("AuthBaseURL = %q, want %q", got, want)
+	}
+	if got, want := cfg.Config.Endpoint.AuthURL, "https://auth.dev.onkernel.com/authorize"; got != want {
+		t.Fatalf("AuthURL = %q, want %q", got, want)
+	}
+	if got, want := cfg.Config.Endpoint.TokenURL, "https://auth.dev.onkernel.com/token"; got != want {
+		t.Fatalf("TokenURL = %q, want %q", got, want)
+	}
+	if got, want := cfg.Config.ClientID, "staging-client-id"; got != want {
+		t.Fatalf("ClientID = %q, want %q", got, want)
+	}
+}
+
+func TestTokenRefreshConfigPrefersStoredValues(t *testing.T) {
+	t.Setenv("KERNEL_AUTH_BASE_URL", "https://auth.dev.onkernel.com")
+	t.Setenv("KERNEL_OAUTH_CLIENT_ID", "staging-client-id")
+
+	tokens := &TokenStorage{
+		AuthBaseURL:   "https://auth.saved.onkernel.com/",
+		OAuthClientID: "saved-client-id",
+	}
+
+	if got, want := tokenAuthBaseURL(tokens), "https://auth.saved.onkernel.com"; got != want {
+		t.Fatalf("tokenAuthBaseURL = %q, want %q", got, want)
+	}
+	if got, want := tokenOAuthClientID(tokens), "saved-client-id"; got != want {
+		t.Fatalf("tokenOAuthClientID = %q, want %q", got, want)
+	}
+}
+
+func TestLegacyTokenRefreshConfigUsesProdDefaults(t *testing.T) {
+	t.Setenv("KERNEL_AUTH_BASE_URL", "https://auth.dev.onkernel.com")
+	t.Setenv("KERNEL_OAUTH_CLIENT_ID", "staging-client-id")
+
+	tokens := &TokenStorage{}
+
+	if got, want := tokenAuthBaseURL(tokens), DefaultAuthBaseURL; got != want {
+		t.Fatalf("tokenAuthBaseURL = %q, want %q", got, want)
+	}
+	if got, want := tokenOAuthClientID(tokens), DefaultClientID; got != want {
+		t.Fatalf("tokenOAuthClientID = %q, want %q", got, want)
+	}
+}

--- a/pkg/auth/storage.go
+++ b/pkg/auth/storage.go
@@ -17,10 +17,12 @@ const (
 
 // TokenStorage represents stored authentication tokens
 type TokenStorage struct {
-	AccessToken  string    `json:"access_token"`
-	RefreshToken string    `json:"refresh_token"`
-	ExpiresAt    time.Time `json:"expires_at"`
-	OrgID        string    `json:"org_id"`
+	AccessToken   string    `json:"access_token"`
+	RefreshToken  string    `json:"refresh_token"`
+	ExpiresAt     time.Time `json:"expires_at"`
+	OrgID         string    `json:"org_id"`
+	AuthBaseURL   string    `json:"auth_base_url,omitempty"`
+	OAuthClientID string    `json:"oauth_client_id,omitempty"`
 }
 
 // IsExpired checks if the access token is expired (with 5 minute buffer)


### PR DESCRIPTION
## Summary
- add KERNEL_AUTH_BASE_URL and KERNEL_OAUTH_CLIENT_ID overrides for CLI OAuth login
- store auth URL/client ID metadata with OAuth tokens so refresh uses the issuing auth server
- show API/Auth URL details in kernel login and kernel auth output

## Example
```bash
KERNEL_BASE_URL=https://api.dev.onkernel.com \
KERNEL_AUTH_BASE_URL=https://auth.dev.onkernel.com \
KERNEL_OAUTH_CLIENT_ID=<staging-client-id> \
kernel login --force
```

## Testing
- go test ./pkg/auth ./cmd
- go test ./...
- go build ./...

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication endpoints, credential JSON shape, and refresh behavior; mitigated by defaults for legacy tokens and targeted tests.
> 
> **Overview**
> Adds **environment-driven OAuth targeting** for non-production workflows: `KERNEL_AUTH_BASE_URL` and `KERNEL_OAUTH_CLIENT_ID` override the hardcoded production auth host and client ID when starting a login.
> 
> **Persisted token metadata** (`auth_base_url`, `oauth_client_id`) is saved with OAuth credentials so **token refresh** hits the same auth server and client that issued the session, with fallbacks to production defaults for older stored tokens.
> 
> `kernel login` and `kernel auth` now print the effective **API URL** (via existing `KERNEL_BASE_URL` / `util.GetBaseURL()`), **auth URL**, and a **masked OAuth client ID** so users can confirm which environment they are using.
> 
> Unit tests cover env overrides at login, stored values on refresh, and legacy tokens without stored metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef2892b38db331300edcd073569207554e9619ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->