### PR TITLE
Add projects update command

### DIFF
--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -22,6 +22,7 @@ type ProjectsService interface {
 	ProjectListService
 	New(ctx context.Context, body kernel.ProjectNewParams, opts ...option.RequestOption) (res *kernel.Project, err error)
 	Get(ctx context.Context, id string, opts ...option.RequestOption) (res *kernel.Project, err error)
+	Update(ctx context.Context, id string, body kernel.ProjectUpdateParams, opts ...option.RequestOption) (res *kernel.Project, err error)
 	Delete(ctx context.Context, id string, opts ...option.RequestOption) (err error)
 }
 
@@ -45,6 +46,12 @@ type ProjectsCreateInput struct {
 
 type ProjectsGetInput struct {
 	Identifier string
+	Output     string
+}
+
+type ProjectsUpdateInput struct {
+	Identifier string
+	Name       string
 	Output     string
 }
 
@@ -152,6 +159,40 @@ func (c ProjectsCmd) Get(ctx context.Context, in ProjectsGetInput) error {
 		{"Updated At", util.FormatLocal(project.UpdatedAt)},
 	}
 	PrintTableNoPad(table, true)
+	return nil
+}
+
+func (c ProjectsCmd) Update(ctx context.Context, in ProjectsUpdateInput) error {
+	if err := validateJSONOutput(in.Output); err != nil {
+		return err
+	}
+	if in.Name == "" {
+		return util.RequiredFlag("--name", "<name>")
+	}
+
+	projectID, err := resolveProjectArg(ctx, c.projects, in.Identifier)
+	if err != nil {
+		return err
+	}
+
+	project, err := c.projects.Update(ctx, projectID, kernel.ProjectUpdateParams{
+		UpdateProjectRequest: kernel.UpdateProjectRequestParam{
+			Name: kernel.String(in.Name),
+		},
+	})
+	if err != nil {
+		return util.CleanedUpSdkError{Err: err}
+	}
+
+	if in.Output == "json" {
+		if project == nil {
+			fmt.Println("null")
+			return nil
+		}
+		return util.PrintPrettyJSON(project)
+	}
+
+	pterm.Success.Printf("Updated project: %s (ID: %s)\n", project.Name, project.ID)
 	return nil
 }
 
@@ -297,6 +338,17 @@ func runProjectsGet(cmd *cobra.Command, args []string) error {
 	return c.Get(cmd.Context(), ProjectsGetInput{Identifier: args[0], Output: output})
 }
 
+func runProjectsUpdate(cmd *cobra.Command, args []string) error {
+	c := getProjectsHandler(cmd)
+	name, _ := cmd.Flags().GetString("name")
+	output, _ := cmd.Flags().GetString("output")
+	return c.Update(cmd.Context(), ProjectsUpdateInput{
+		Identifier: args[0],
+		Name:       name,
+		Output:     output,
+	})
+}
+
 func runProjectsDelete(cmd *cobra.Command, args []string) error {
 	c := getProjectsHandler(cmd)
 	return c.Delete(cmd.Context(), ProjectsDeleteInput{Identifier: args[0]})
@@ -371,6 +423,13 @@ var projectsGetCmd = &cobra.Command{
 	RunE:  runProjectsGet,
 }
 
+var projectsUpdateCmd = &cobra.Command{
+	Use:   "update <id-or-name>",
+	Short: "Update a project",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runProjectsUpdate,
+}
+
 var projectsDeleteCmd = &cobra.Command{
 	Use:   "delete <id-or-name>",
 	Short: "Delete a project",
@@ -419,6 +478,9 @@ var projectsSetLimitsCompatCmd = &cobra.Command{
 func init() {
 	addJSONOutputFlag(projectsListCmd)
 	addJSONOutputFlag(projectsGetCmd)
+	addJSONOutputFlag(projectsUpdateCmd)
+	projectsUpdateCmd.Flags().String("name", "", "New project name (required)")
+	_ = projectsUpdateCmd.MarkFlagRequired("name")
 	addJSONOutputFlag(projectsLimitsGetCmd)
 	addProjectsLimitsSetFlags(projectsLimitsSetCmd)
 	addJSONOutputFlag(projectsGetLimitsCompatCmd)
@@ -430,6 +492,7 @@ func init() {
 	projectsCmd.AddCommand(projectsListCmd)
 	projectsCmd.AddCommand(projectsCreateCmd)
 	projectsCmd.AddCommand(projectsGetCmd)
+	projectsCmd.AddCommand(projectsUpdateCmd)
 	projectsCmd.AddCommand(projectsDeleteCmd)
 	projectsCmd.AddCommand(projectsLimitsCmd)
 	projectsCmd.AddCommand(projectsGetLimitsCompatCmd)

--- a/cmd/projects_test.go
+++ b/cmd/projects_test.go
@@ -21,6 +21,7 @@ type FakeProjectsService struct {
 	ListFunc   func(ctx context.Context, query kernel.ProjectListParams, opts ...option.RequestOption) (*pagination.OffsetPagination[kernel.Project], error)
 	NewFunc    func(ctx context.Context, body kernel.ProjectNewParams, opts ...option.RequestOption) (*kernel.Project, error)
 	GetFunc    func(ctx context.Context, id string, opts ...option.RequestOption) (*kernel.Project, error)
+	UpdateFunc func(ctx context.Context, id string, body kernel.ProjectUpdateParams, opts ...option.RequestOption) (*kernel.Project, error)
 	DeleteFunc func(ctx context.Context, id string, opts ...option.RequestOption) error
 }
 
@@ -43,6 +44,13 @@ func (f *FakeProjectsService) Get(ctx context.Context, id string, opts ...option
 		return f.GetFunc(ctx, id, opts...)
 	}
 	return &kernel.Project{ID: id, Name: "default"}, nil
+}
+
+func (f *FakeProjectsService) Update(ctx context.Context, id string, body kernel.ProjectUpdateParams, opts ...option.RequestOption) (*kernel.Project, error) {
+	if f.UpdateFunc != nil {
+		return f.UpdateFunc(ctx, id, body, opts...)
+	}
+	return &kernel.Project{ID: id, Name: body.UpdateProjectRequest.Name.Value}, nil
 }
 
 func (f *FakeProjectsService) Delete(ctx context.Context, id string, opts ...option.RequestOption) error {
@@ -141,6 +149,116 @@ func TestProjectsGet_InvalidOutput(t *testing.T) {
 	}
 
 	err := c.Get(context.Background(), ProjectsGetInput{Identifier: "a12345678901234567890123", Output: "yaml"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported --output value")
+}
+
+func TestProjectsUpdate_Success(t *testing.T) {
+	buf := capturePtermOutput(t)
+	c := ProjectsCmd{
+		projects: &FakeProjectsService{
+			UpdateFunc: func(ctx context.Context, id string, body kernel.ProjectUpdateParams, opts ...option.RequestOption) (*kernel.Project, error) {
+				assert.Equal(t, "a12345678901234567890123", id)
+				assert.True(t, body.UpdateProjectRequest.Name.Valid())
+				assert.Equal(t, "Renamed", body.UpdateProjectRequest.Name.Value)
+				return &kernel.Project{ID: id, Name: body.UpdateProjectRequest.Name.Value}, nil
+			},
+		},
+	}
+
+	err := c.Update(context.Background(), ProjectsUpdateInput{
+		Identifier: "a12345678901234567890123",
+		Name:       "Renamed",
+	})
+
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "Updated project: Renamed")
+	assert.Contains(t, out, "a12345678901234567890123")
+}
+
+func TestProjectsUpdate_JSONOutput(t *testing.T) {
+	project := mustProject(t, `{"id":"a12345678901234567890123","name":"Renamed","status":"active","created_at":"2026-05-29T12:00:00Z","updated_at":"2026-05-29T12:30:00Z"}`)
+	c := ProjectsCmd{
+		projects: &FakeProjectsService{
+			UpdateFunc: func(ctx context.Context, id string, body kernel.ProjectUpdateParams, opts ...option.RequestOption) (*kernel.Project, error) {
+				assert.Equal(t, "a12345678901234567890123", id)
+				assert.True(t, body.UpdateProjectRequest.Name.Valid())
+				assert.Equal(t, "Renamed", body.UpdateProjectRequest.Name.Value)
+				return &project, nil
+			},
+		},
+	}
+
+	var err error
+	out := captureStdout(t, func() {
+		err = c.Update(context.Background(), ProjectsUpdateInput{
+			Identifier: "a12345678901234567890123",
+			Name:       "Renamed",
+			Output:     "json",
+		})
+	})
+
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"id":"a12345678901234567890123","name":"Renamed","status":"active","created_at":"2026-05-29T12:00:00Z","updated_at":"2026-05-29T12:30:00Z"}`, out)
+}
+
+func TestProjectsUpdate_ResolvesName(t *testing.T) {
+	c := ProjectsCmd{
+		projects: &FakeProjectsService{
+			ListFunc: func(ctx context.Context, query kernel.ProjectListParams, opts ...option.RequestOption) (*pagination.OffsetPagination[kernel.Project], error) {
+				return &pagination.OffsetPagination[kernel.Project]{
+					Items: []kernel.Project{{ID: "a12345678901234567890123", Name: "Default"}},
+				}, nil
+			},
+			UpdateFunc: func(ctx context.Context, id string, body kernel.ProjectUpdateParams, opts ...option.RequestOption) (*kernel.Project, error) {
+				assert.Equal(t, "a12345678901234567890123", id)
+				return &kernel.Project{ID: id, Name: body.UpdateProjectRequest.Name.Value}, nil
+			},
+		},
+	}
+
+	err := c.Update(context.Background(), ProjectsUpdateInput{
+		Identifier: "default",
+		Name:       "Renamed",
+	})
+
+	require.NoError(t, err)
+}
+
+func TestProjectsUpdate_RequiresName(t *testing.T) {
+	c := ProjectsCmd{
+		projects: &FakeProjectsService{
+			UpdateFunc: func(ctx context.Context, id string, body kernel.ProjectUpdateParams, opts ...option.RequestOption) (*kernel.Project, error) {
+				t.Fatal("Update should not be called")
+				return nil, nil
+			},
+		},
+	}
+
+	err := c.Update(context.Background(), ProjectsUpdateInput{Identifier: "a12345678901234567890123"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--name is required")
+	assert.Contains(t, err.Error(), "add --name <name>")
+}
+
+func TestProjectsUpdate_InvalidOutput(t *testing.T) {
+	c := ProjectsCmd{
+		projects: &FakeProjectsService{
+			UpdateFunc: func(ctx context.Context, id string, body kernel.ProjectUpdateParams, opts ...option.RequestOption) (*kernel.Project, error) {
+				t.Fatal("Update should not be called")
+				return nil, nil
+			},
+		},
+	}
+
+	err := c.Update(context.Background(), ProjectsUpdateInput{
+		Identifier: "a12345678901234567890123",
+		Name:       "Renamed",
+		Output:     "yaml",
+	})
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported --output value")


### PR DESCRIPTION
## Summary

Adds `kernel projects update <id-or-name> --name <name>` to close the projects CRUD parity gap in the CLI.

## What Changed

- Wires `ProjectsService.Update` to the generated Go SDK `Projects.Update` method.
- Adds `ProjectsUpdateInput` and `ProjectsCmd.Update` with the existing `<id-or-name>` resolver.
- Adds `--name` as the required update field.
- Adds `--output json`, matching the existing project read/update-style commands that return SDK objects.
- Registers the new `projects update` Cobra command.
- Adds focused tests for:
  - successful name update
  - JSON output
  - resolving a project by name before update
  - missing `--name`
  - invalid `--output`

## Why

`projects create`, `projects get`, `projects list`, and `projects delete` already existed, and the SDK already exposes project update. This PR keeps the CLI change surgical by adding name update only, leaving browser telemetry parity for a separate UX/API-design PR.

## Verification

- `env GOCACHE=/private/tmp/kernel-cli-go-cache go test ./cmd -run 'TestProjects(Update|List|Get|Limits|Resolve)'`
- `env GOCACHE=/private/tmp/kernel-cli-go-cache go test ./cmd ./pkg/util`
  - First sandbox run hit the known `httptest` local-port restriction; rerun outside the sandbox passed.
- `make test`
- `make build`
- `./bin/kernel projects update --help`

Production smoke against `https://api.onkernel.com`:

- Created a disposable project.
- Renamed it via `kernel projects update <old-name> --name <new-name> --output json`.
- Verified the renamed project via `kernel projects get <new-name> --output json`.
- Deleted the disposable project and confirmed cleanup.

Localhost smoke:

- Attempted against `http://localhost:3001`, but the local API key available in this thread is no longer valid for the current local server state, so the smoke stopped before creating any resource.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Surgical CLI addition with validation and tests; no auth or core infrastructure changes.
> 
> **Overview**
> Adds **`kernel projects update <id-or-name> --name <name>`** so the CLI can rename projects via the existing Go SDK **`Projects.Update`** path, matching create/get/delete patterns.
> 
> The handler resolves **ID or name** (same as other project commands), requires **`--name`**, supports **`--output json`**, and prints a success line otherwise. **`FakeProjectsService`** and unit tests cover success, JSON output, name resolution, missing `--name`, and invalid `--output`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 730cc3b9e2cf135b4464a0b14c0746cd797d2fe0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->