### PR TITLE
Migrate GoReleaser Homebrew config to casks

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,17 +26,15 @@ archives:
     formats: [tar.gz]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
-brews:
+homebrew_casks:
   - name: kernel
     repository:
       owner: kernel
       name: homebrew-tap
       branch: main
-    directory: Formula
+    directory: Casks
     description: "Kernel CLI"
     homepage: "https://github.com/kernel/cli"
-    test: |
-      system "#{bin}/kernel", "--version"
 
 npms:
   - name: "@onkernel/cli"


### PR DESCRIPTION
## What

Migrate the CLI release config from GoReleaser `brews` to `homebrew_casks`.

- Replace `brews:` with `homebrew_casks:`
- Move generated Homebrew output from `Formula` to `Casks`
- Remove the old formula-only `test` stanza

## Why

GoReleaser Pro 2.16 fails the repo release dry run during `goreleaser check` because `brews` is now deprecated for prebuilt binary distribution.

Before this change, `make release-dry-run` stopped before artifact generation with:

```text
DEPRECATED: brews should not be used anymore
.goreleaser.yaml error=configuration is valid, but uses deprecated properties
```

This blocks the CLI tag release path. `homebrew_casks` is the current GoReleaser path for publishing prebuilt binaries through Homebrew.

## How

This keeps the existing release behavior scoped to the Homebrew publisher config:

- Same cask name: `kernel`
- Same tap repository: `kernel/homebrew-tap`
- Same branch: `main`
- Same description and homepage
- Same archive, npm, changelog, and GitHub release config

The generated Homebrew artifact now lands at `dist/homebrew/Casks/kernel.rb` in dry runs.

## Verification

- `goreleaser check`
- `git diff --check -- .goreleaser.yaml`
- `GOCACHE=/private/tmp/kernel-cli-go-cache GOMODCACHE=/private/tmp/kernel-cli-go-modcache make release-dry-run`

Dry-run result:

- GoReleaser config validation passed
- GoReleaser healthcheck passed
- darwin/linux/windows archives generated
- Homebrew cask generated at `dist/homebrew/Casks/kernel.rb`
- npm package metadata generated
- `go.mod` and `go.sum` unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-pipeline config only; no runtime CLI, auth, or application logic changes.
> 
> **Overview**
> Updates **GoReleaser** so CLI releases use the supported Homebrew publisher for prebuilt binaries instead of the deprecated **`brews`** block.
> 
> **`.goreleaser.yaml`** now declares **`homebrew_casks`** (same tap `kernel/homebrew-tap`, cask name `kernel`, branch `main`) and writes into **`Casks`** instead of **`Formula`**. The formula-only **`test`** stanza is removed. Archives, npm, changelog, and GitHub release settings are unchanged; dry runs emit **`dist/homebrew/Casks/kernel.rb`** and **`goreleaser check`** / release dry-run pass without the deprecation error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c84ea929dad3890445233f4a3f899dd302e5020f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->