### PR TITLE
ci: use org variable for CURSOR_PREFERRED_MODEL

### DIFF
--- a/.github/workflows/fix-ci.yaml
+++ b/.github/workflows/fix-ci.yaml
@@ -102,4 +102,4 @@ jobs:
           - Avoid duplicate comments - update existing bot comments
           - If no actionable fix is possible, make no changes and post no comment
           - PR comments must ONLY include the PR creation link, no manual merge instructions
-          " --model ${{ secrets.CURSOR_PREFERRED_MODEL }} --force --output-format=text
+          " --model ${{ vars.CURSOR_PREFERRED_MODEL }} --force --output-format=text


### PR DESCRIPTION
Switches `agent --model ${{ secrets.CURSOR_PREFERRED_MODEL }}` to `${{ vars.CURSOR_PREFERRED_MODEL }}` so the model value is visible in plaintext.

The org-wide variable `CURSOR_PREFERRED_MODEL` has been set to `claude-opus-4-8-thinking-max`.

Part of an org-wide migration of this key from secret to variable. The secret will be deleted once all repos are migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow input change with no application or auth logic changes; model name exposure is intentional per org migration.
> 
> **Overview**
> Updates the **Fix CI Failures** workflow so `cursor-agent` reads the preferred model from a GitHub **organization variable** (`vars.CURSOR_PREFERRED_MODEL`) instead of a **secret** (`secrets.CURSOR_PREFERRED_MODEL`).
> 
> This matches an org-wide move to store the model name in plaintext (e.g. `claude-opus-4-8-thinking-max`) while other credentials stay in secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dd4fe1fc501932000c000a4e83c1056b9c85473. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->