### PR TITLE
Disable color output when stdout is not a TTY

### DIFF
--- a/cmd/color_test.go
+++ b/cmd/color_test.go
@@ -1,0 +1,24 @@
+package cmd
+
+import "testing"
+
+func TestShouldEnableColor(t *testing.T) {
+	tests := []struct {
+		name       string
+		noColorEnv string
+		isTTY      bool
+		want       bool
+	}{
+		{"tty, no env", "", true, true},
+		{"not tty, no env", "", false, false},
+		{"tty, NO_COLOR set", "1", true, false},
+		{"not tty, NO_COLOR set", "1", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldEnableColor(tt.noColorEnv, tt.isTTY); got != tt.want {
+				t.Errorf("shouldEnableColor(%q, %v) = %v, want %v", tt.noColorEnv, tt.isTTY, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kernel/cli/cmd/mcp"
 	"github.com/kernel/cli/cmd/proxies"
 	"github.com/kernel/cli/pkg/auth"
+	"github.com/kernel/cli/pkg/table"
 	"github.com/kernel/cli/pkg/update"
 	"github.com/kernel/cli/pkg/util"
 	"github.com/kernel/kernel-go-sdk"
@@ -177,9 +178,22 @@ func init() {
 	}
 }
 
+// shouldEnableColor decides whether pterm color styling should be on.
+// NO_COLOR (any non-empty value) always wins per https://no-color.org.
+// Otherwise color is enabled only when stdout is an interactive terminal.
+func shouldEnableColor(noColorEnv string, isTTY bool) bool {
+	if noColorEnv != "" {
+		return false
+	}
+	return isTTY
+}
+
 func initConfig() {
-	// Placeholder for future configuration (env vars, config files, etc.)
-	pterm.EnableStyling() // ensure pterm is initialised in case env disables it
+	if shouldEnableColor(os.Getenv("NO_COLOR"), table.IsStdoutTTY()) {
+		pterm.EnableStyling()
+	} else {
+		pterm.DisableStyling()
+	}
 }
 
 // Execute executes the root command.


### PR DESCRIPTION
## Summary

When the CLI runs in a non-interactive environment (stdout piped or captured), it emitted raw ANSI escape codes instead of plain text — e.g. `^[[30;42m SUCCESS ^[[0m^[[0m`. This is because `pterm` (v0.12.80) forces color on regardless of the output target and does not auto-detect a TTY. The previous `initConfig()` made this worse by calling `pterm.EnableStyling()` unconditionally.

This change gates pterm styling on an interactive-terminal check:

- Color is enabled only when stdout is a TTY **and** `NO_COLOR` is unset.
- Otherwise pterm styling is disabled, so piped/captured output is plain text.
- The existing `--no-color` flag and its handling in `PersistentPreRunE` are unchanged (it runs after `initConfig` and can only further-disable).

`fang`/`lipgloss` (help text and the error renderer) already strip color correctly on a non-TTY, so no change was needed there. The fix is isolated to pterm in `cmd/root.go`.

## Changes

- `cmd/root.go`: add `shouldEnableColor(noColorEnv, isTTY)` helper; rewrite `initConfig()` to enable/disable pterm styling based on it (reusing `pkg/table.IsStdoutTTY()`).
- `cmd/color_test.go`: table test for the precedence logic.

## Test plan

- [x] `go build ./...` and `make build` succeed
- [x] `go test ./cmd/...` passes (incl. new `TestShouldEnableColor`)
- [x] `go vet ./cmd/` and `gofmt` clean
- [x] Piped output verified free of ANSI escapes: confirmed an auth-exempt pterm path (`upgrade --dry-run`) prints plain `INFO:`/`WARNING:` when piped, and that the pre-fix build leaked `^[[…m` on the same path
- [ ] Manual check that an interactive terminal still shows color (not exercisable in CI/headless; covered by the `isTTY=true` unit case)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup-only output styling change with unit tests; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes **pterm** emitting raw ANSI escapes when stdout is piped or captured by no longer calling `pterm.EnableStyling()` unconditionally at startup.
> 
> **`initConfig()`** now turns styling on only when stdout is a TTY and **`NO_COLOR`** is unset; otherwise it calls **`pterm.DisableStyling()`**. A new **`shouldEnableColor`** helper encodes that precedence (any non-empty **`NO_COLOR`** disables color). TTY detection reuses **`table.IsStdoutTTY()`**. Table tests cover the four combinations of TTY and env.
> 
> The **`--no-color`** flag path in **`PersistentPreRunE`** is unchanged and can still disable styling after init.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b86de28a062fdeabb5da55b36e6f0bcc69428835. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->