### PR TITLE
Bump kernel-go-sdk to v0.64.0 and migrate to paginated List

### DIFF
--- a/cmd/browser_pools.go
+++ b/cmd/browser_pools.go
@@ -8,13 +8,14 @@ import (
 	"github.com/kernel/cli/pkg/util"
 	"github.com/kernel/kernel-go-sdk"
 	"github.com/kernel/kernel-go-sdk/option"
+	"github.com/kernel/kernel-go-sdk/packages/pagination"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
 
 // BrowserPoolsService defines the subset of the Kernel SDK browser pools client that we use.
 type BrowserPoolsService interface {
-	List(ctx context.Context, opts ...option.RequestOption) (res *[]kernel.BrowserPool, err error)
+	List(ctx context.Context, query kernel.BrowserPoolListParams, opts ...option.RequestOption) (res *pagination.OffsetPagination[kernel.BrowserPool], err error)
 	New(ctx context.Context, body kernel.BrowserPoolNewParams, opts ...option.RequestOption) (res *kernel.BrowserPool, err error)
 	Get(ctx context.Context, id string, opts ...option.RequestOption) (res *kernel.BrowserPool, err error)
 	Update(ctx context.Context, id string, body kernel.BrowserPoolUpdateParams, opts ...option.RequestOption) (res *kernel.BrowserPool, err error)
@@ -37,20 +38,25 @@ func (c BrowserPoolsCmd) List(ctx context.Context, in BrowserPoolsListInput) err
 		return err
 	}
 
-	pools, err := c.client.List(ctx)
+	page, err := c.client.List(ctx, kernel.BrowserPoolListParams{})
 	if err != nil {
 		return util.CleanedUpSdkError{Err: err}
 	}
 
+	var pools []kernel.BrowserPool
+	if page != nil {
+		pools = page.Items
+	}
+
 	if in.Output == "json" {
-		if pools == nil || len(*pools) == 0 {
+		if len(pools) == 0 {
 			fmt.Println("[]")
 			return nil
 		}
-		return util.PrintPrettyJSONSlice(*pools)
+		return util.PrintPrettyJSONSlice(pools)
 	}
 
-	if pools == nil || len(*pools) == 0 {
+	if len(pools) == 0 {
 		pterm.Info.Println("No browser pools found")
 		return nil
 	}
@@ -59,7 +65,7 @@ func (c BrowserPoolsCmd) List(ctx context.Context, in BrowserPoolsListInput) err
 		{"ID", "Name", "Available", "Acquired", "Created At", "Size"},
 	}
 
-	for _, p := range *pools {
+	for _, p := range pools {
 		tableData = append(tableData, []string{
 			p.ID,
 			util.OrDash(p.Name),
@@ -250,7 +256,7 @@ func (c BrowserPoolsCmd) Update(ctx context.Context, in BrowserPoolsUpdateInput)
 		params.Name = kernel.String(in.Name)
 	}
 	if in.Size > 0 {
-		params.Size = in.Size
+		params.Size = kernel.Int(in.Size)
 	}
 	if in.FillRate > 0 {
 		params.FillRatePerMinute = kernel.Int(in.FillRate)

--- a/cmd/credential_providers.go
+++ b/cmd/credential_providers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kernel/cli/pkg/util"
 	"github.com/kernel/kernel-go-sdk"
 	"github.com/kernel/kernel-go-sdk/option"
+	"github.com/kernel/kernel-go-sdk/packages/pagination"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
@@ -17,7 +18,7 @@ type CredentialProvidersService interface {
 	New(ctx context.Context, body kernel.CredentialProviderNewParams, opts ...option.RequestOption) (res *kernel.CredentialProvider, err error)
 	Get(ctx context.Context, id string, opts ...option.RequestOption) (res *kernel.CredentialProvider, err error)
 	Update(ctx context.Context, id string, body kernel.CredentialProviderUpdateParams, opts ...option.RequestOption) (res *kernel.CredentialProvider, err error)
-	List(ctx context.Context, opts ...option.RequestOption) (res *[]kernel.CredentialProvider, err error)
+	List(ctx context.Context, query kernel.CredentialProviderListParams, opts ...option.RequestOption) (res *pagination.OffsetPagination[kernel.CredentialProvider], err error)
 	Delete(ctx context.Context, id string, opts ...option.RequestOption) (err error)
 	Test(ctx context.Context, id string, opts ...option.RequestOption) (res *kernel.CredentialProviderTestResult, err error)
 	ListItems(ctx context.Context, id string, opts ...option.RequestOption) (res *kernel.CredentialProviderListItemsResponse, err error)
@@ -75,26 +76,31 @@ func (c CredentialProvidersCmd) List(ctx context.Context, in CredentialProviders
 		return err
 	}
 
-	providers, err := c.providers.List(ctx)
+	page, err := c.providers.List(ctx, kernel.CredentialProviderListParams{})
 	if err != nil {
 		return util.CleanedUpSdkError{Err: err}
 	}
 
+	var providers []kernel.CredentialProvider
+	if page != nil {
+		providers = page.Items
+	}
+
 	if in.Output == "json" {
-		if providers == nil || len(*providers) == 0 {
+		if len(providers) == 0 {
 			fmt.Println("[]")
 			return nil
 		}
-		return util.PrintPrettyJSONSlice(*providers)
+		return util.PrintPrettyJSONSlice(providers)
 	}
 
-	if providers == nil || len(*providers) == 0 {
+	if len(providers) == 0 {
 		pterm.Info.Println("No credential providers found")
 		return nil
 	}
 
 	tableData := pterm.TableData{{"ID", "Provider Type", "Enabled", "Priority", "Created At"}}
-	for _, p := range *providers {
+	for _, p := range providers {
 		tableData = append(tableData, []string{
 			p.ID,
 			string(p.ProviderType),

--- a/cmd/extensions.go
+++ b/cmd/extensions.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kernel/cli/pkg/util"
 	"github.com/kernel/kernel-go-sdk"
 	"github.com/kernel/kernel-go-sdk/option"
+	"github.com/kernel/kernel-go-sdk/packages/pagination"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
@@ -43,7 +44,7 @@ var defaultExtensionExclusions = util.ZipOptions{
 
 // ExtensionsService defines the subset of the Kernel SDK extension client that we use.
 type ExtensionsService interface {
-	List(ctx context.Context, opts ...option.RequestOption) (res *[]kernel.ExtensionListResponse, err error)
+	List(ctx context.Context, query kernel.ExtensionListParams, opts ...option.RequestOption) (res *pagination.OffsetPagination[kernel.ExtensionListResponse], err error)
 	Delete(ctx context.Context, idOrName string, opts ...option.RequestOption) (err error)
 	Download(ctx context.Context, idOrName string, opts ...option.RequestOption) (res *http.Response, err error)
 	DownloadFromChromeStore(ctx context.Context, query kernel.ExtensionDownloadFromChromeStoreParams, opts ...option.RequestOption) (res *http.Response, err error)
@@ -89,25 +90,30 @@ func (e ExtensionsCmd) List(ctx context.Context, in ExtensionsListInput) error {
 	if in.Output != "json" {
 		pterm.Info.Println("Fetching extensions...")
 	}
-	items, err := e.extensions.List(ctx)
+	page, err := e.extensions.List(ctx, kernel.ExtensionListParams{})
 	if err != nil {
 		return util.CleanedUpSdkError{Err: err}
 	}
 
+	var items []kernel.ExtensionListResponse
+	if page != nil {
+		items = page.Items
+	}
+
 	if in.Output == "json" {
-		if items == nil || len(*items) == 0 {
+		if len(items) == 0 {
 			fmt.Println("[]")
 			return nil
 		}
-		return util.PrintPrettyJSONSlice(*items)
+		return util.PrintPrettyJSONSlice(items)
 	}
 
-	if items == nil || len(*items) == 0 {
+	if len(items) == 0 {
 		pterm.Info.Println("No extensions found")
 		return nil
 	}
 	rows := pterm.TableData{{"Extension ID", "Name", "Created At", "Size (bytes)", "Last Used At"}}
-	for _, it := range *items {
+	for _, it := range items {
 		name := it.Name
 		if name == "" {
 			name = "-"

--- a/cmd/extensions_test.go
+++ b/cmd/extensions_test.go
@@ -14,24 +14,24 @@ import (
 
 	"github.com/kernel/kernel-go-sdk"
 	"github.com/kernel/kernel-go-sdk/option"
+	"github.com/kernel/kernel-go-sdk/packages/pagination"
 	"github.com/stretchr/testify/assert"
 )
 
 // FakeExtensionsService implements ExtensionsService
 type FakeExtensionsService struct {
-	ListFunc                  func(ctx context.Context, opts ...option.RequestOption) (*[]kernel.ExtensionListResponse, error)
+	ListFunc                  func(ctx context.Context, query kernel.ExtensionListParams, opts ...option.RequestOption) (*pagination.OffsetPagination[kernel.ExtensionListResponse], error)
 	DeleteFunc                func(ctx context.Context, idOrName string, opts ...option.RequestOption) error
 	DownloadFunc              func(ctx context.Context, idOrName string, opts ...option.RequestOption) (*http.Response, error)
 	DownloadFromChromeStoreFn func(ctx context.Context, query kernel.ExtensionDownloadFromChromeStoreParams, opts ...option.RequestOption) (*http.Response, error)
 	UploadFunc                func(ctx context.Context, body kernel.ExtensionUploadParams, opts ...option.RequestOption) (*kernel.ExtensionUploadResponse, error)
 }
 
-func (f *FakeExtensionsService) List(ctx context.Context, opts ...option.RequestOption) (*[]kernel.ExtensionListResponse, error) {
+func (f *FakeExtensionsService) List(ctx context.Context, query kernel.ExtensionListParams, opts ...option.RequestOption) (*pagination.OffsetPagination[kernel.ExtensionListResponse], error) {
 	if f.ListFunc != nil {
-		return f.ListFunc(ctx, opts...)
+		return f.ListFunc(ctx, query, opts...)
 	}
-	empty := []kernel.ExtensionListResponse{}
-	return &empty, nil
+	return &pagination.OffsetPagination[kernel.ExtensionListResponse]{}, nil
 }
 func (f *FakeExtensionsService) Delete(ctx context.Context, idOrName string, opts ...option.RequestOption) error {
 	if f.DeleteFunc != nil {
@@ -70,8 +70,8 @@ func TestExtensionsList_WithRows(t *testing.T) {
 	buf := capturePtermOutput(t)
 	created := time.Unix(0, 0)
 	rows := []kernel.ExtensionListResponse{{ID: "e1", Name: "alpha", CreatedAt: created, SizeBytes: 10}, {ID: "e2", Name: "", CreatedAt: created, SizeBytes: 20}}
-	fake := &FakeExtensionsService{ListFunc: func(ctx context.Context, opts ...option.RequestOption) (*[]kernel.ExtensionListResponse, error) {
-		return &rows, nil
+	fake := &FakeExtensionsService{ListFunc: func(ctx context.Context, query kernel.ExtensionListParams, opts ...option.RequestOption) (*pagination.OffsetPagination[kernel.ExtensionListResponse], error) {
+		return &pagination.OffsetPagination[kernel.ExtensionListResponse]{Items: rows}, nil
 	}}
 	e := ExtensionsCmd{extensions: fake}
 	_ = e.List(context.Background(), ExtensionsListInput{})

--- a/cmd/proxies/check.go
+++ b/cmd/proxies/check.go
@@ -128,9 +128,6 @@ func getProxyCheckConfigRows(proxy *kernel.ProxyCheckResponse) [][]string {
 		if config.Asn != "" {
 			rows = append(rows, []string{"ASN", config.Asn})
 		}
-		if config.Carrier != "" {
-			rows = append(rows, []string{"Carrier", config.Carrier})
-		}
 	case kernel.ProxyCheckResponseTypeCustom:
 		if config.Host != "" {
 			rows = append(rows, []string{"Host", config.Host})

--- a/cmd/proxies/common_test.go
+++ b/cmd/proxies/common_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kernel/kernel-go-sdk"
 	"github.com/kernel/kernel-go-sdk/option"
+	"github.com/kernel/kernel-go-sdk/packages/pagination"
 	"github.com/pterm/pterm"
 )
 
@@ -37,19 +38,23 @@ func captureOutput(t *testing.T) *bytes.Buffer {
 
 // FakeProxyService implements ProxyService for testing
 type FakeProxyService struct {
-	ListFunc   func(ctx context.Context, opts ...option.RequestOption) (*[]kernel.ProxyListResponse, error)
+	ListFunc   func(ctx context.Context, query kernel.ProxyListParams, opts ...option.RequestOption) (*pagination.OffsetPagination[kernel.ProxyListResponse], error)
 	GetFunc    func(ctx context.Context, id string, opts ...option.RequestOption) (*kernel.ProxyGetResponse, error)
 	NewFunc    func(ctx context.Context, body kernel.ProxyNewParams, opts ...option.RequestOption) (*kernel.ProxyNewResponse, error)
 	DeleteFunc func(ctx context.Context, id string, opts ...option.RequestOption) error
 	CheckFunc  func(ctx context.Context, id string, body kernel.ProxyCheckParams, opts ...option.RequestOption) (*kernel.ProxyCheckResponse, error)
 }
 
-func (f *FakeProxyService) List(ctx context.Context, opts ...option.RequestOption) (*[]kernel.ProxyListResponse, error) {
+func (f *FakeProxyService) List(ctx context.Context, query kernel.ProxyListParams, opts ...option.RequestOption) (*pagination.OffsetPagination[kernel.ProxyListResponse], error) {
 	if f.ListFunc != nil {
-		return f.ListFunc(ctx, opts...)
+		return f.ListFunc(ctx, query, opts...)
 	}
-	empty := []kernel.ProxyListResponse{}
-	return &empty, nil
+	return &pagination.OffsetPagination[kernel.ProxyListResponse]{}, nil
+}
+
+// proxyListPage wraps proxies in an OffsetPagination page for test fakes.
+func proxyListPage(proxies []kernel.ProxyListResponse) *pagination.OffsetPagination[kernel.ProxyListResponse] {
+	return &pagination.OffsetPagination[kernel.ProxyListResponse]{Items: proxies}
 }
 
 func (f *FakeProxyService) Get(ctx context.Context, id string, opts ...option.RequestOption) (*kernel.ProxyGetResponse, error) {

--- a/cmd/proxies/create.go
+++ b/cmd/proxies/create.go
@@ -48,25 +48,25 @@ func (p ProxyCmd) Create(ctx context.Context, in ProxyCreateInput) error {
 	// Build config based on type
 	switch proxyType {
 	case kernel.ProxyNewParamsTypeDatacenter:
-		config := kernel.ProxyNewParamsConfigDatacenterProxyConfig{}
+		config := kernel.ProxyNewParamsConfigDatacenter{}
 		if in.Country != "" {
 			config.Country = kernel.Opt(in.Country)
 		}
 		params.Config = kernel.ProxyNewParamsConfigUnion{
-			OfProxyNewsConfigDatacenterProxyConfig: &config,
+			OfDatacenter: &config,
 		}
 
 	case kernel.ProxyNewParamsTypeIsp:
-		config := kernel.ProxyNewParamsConfigIspProxyConfig{}
+		config := kernel.ProxyNewParamsConfigIsp{}
 		if in.Country != "" {
 			config.Country = kernel.Opt(in.Country)
 		}
 		params.Config = kernel.ProxyNewParamsConfigUnion{
-			OfProxyNewsConfigIspProxyConfig: &config,
+			OfIsp: &config,
 		}
 
 	case kernel.ProxyNewParamsTypeResidential:
-		config := kernel.ProxyNewParamsConfigResidentialProxyConfig{}
+		config := kernel.ProxyNewParamsConfigResidential{}
 
 		// Validate that if city is provided, country must also be provided
 		if in.City != "" && in.Country == "" {
@@ -98,11 +98,11 @@ func (p ProxyCmd) Create(ctx context.Context, in ProxyCreateInput) error {
 			}
 		}
 		params.Config = kernel.ProxyNewParamsConfigUnion{
-			OfProxyNewsConfigResidentialProxyConfig: &config,
+			OfResidential: &config,
 		}
 
 	case kernel.ProxyNewParamsTypeMobile:
-		config := kernel.ProxyNewParamsConfigMobileProxyConfig{}
+		config := kernel.ProxyNewParamsConfigMobile{}
 
 		// Validate that if city is provided, country must also be provided
 		if in.City != "" && in.Country == "" {
@@ -118,18 +118,8 @@ func (p ProxyCmd) Create(ctx context.Context, in ProxyCreateInput) error {
 		if in.State != "" {
 			config.State = kernel.Opt(in.State)
 		}
-		if in.Zip != "" {
-			config.Zip = kernel.Opt(in.Zip)
-		}
-		if in.ASN != "" {
-			config.Asn = kernel.Opt(in.ASN)
-		}
-		if in.Carrier != "" {
-			// The API will validate the carrier value
-			config.Carrier = in.Carrier
-		}
 		params.Config = kernel.ProxyNewParamsConfigUnion{
-			OfProxyNewsConfigMobileProxyConfig: &config,
+			OfMobile: &config,
 		}
 
 	case kernel.ProxyNewParamsTypeCustom:
@@ -140,7 +130,7 @@ func (p ProxyCmd) Create(ctx context.Context, in ProxyCreateInput) error {
 			return fmt.Errorf("--port is required for custom proxy type")
 		}
 
-		config := kernel.ProxyNewParamsConfigCreateCustomProxyConfig{
+		config := kernel.ProxyNewParamsConfigCustom{
 			Host: in.Host,
 			Port: int64(in.Port),
 		}
@@ -151,7 +141,7 @@ func (p ProxyCmd) Create(ctx context.Context, in ProxyCreateInput) error {
 			config.Password = kernel.Opt(in.Password)
 		}
 		params.Config = kernel.ProxyNewParamsConfigUnion{
-			OfProxyNewsConfigCreateCustomProxyConfig: &config,
+			OfCustom: &config,
 		}
 	}
 
@@ -219,7 +209,6 @@ func runProxiesCreate(cmd *cobra.Command, args []string) error {
 	zip, _ := cmd.Flags().GetString("zip")
 	asn, _ := cmd.Flags().GetString("asn")
 	os, _ := cmd.Flags().GetString("os")
-	carrier, _ := cmd.Flags().GetString("carrier")
 	host, _ := cmd.Flags().GetString("host")
 	port, _ := cmd.Flags().GetInt("port")
 	username, _ := cmd.Flags().GetString("username")
@@ -241,7 +230,6 @@ func runProxiesCreate(cmd *cobra.Command, args []string) error {
 		Zip:         zip,
 		ASN:         asn,
 		OS:          os,
-		Carrier:     carrier,
 		Host:        host,
 		Port:        port,
 		Username:    username,

--- a/cmd/proxies/create_test.go
+++ b/cmd/proxies/create_test.go
@@ -21,7 +21,7 @@ func TestProxyCreate_Datacenter_Success(t *testing.T) {
 			assert.Equal(t, []string{"localhost", "internal.service.local"}, body.BypassHosts)
 
 			// Check config
-			dcConfig := body.Config.OfProxyNewsConfigDatacenterProxyConfig
+			dcConfig := body.Config.OfDatacenter
 			assert.NotNil(t, dcConfig)
 			assert.Equal(t, "US", dcConfig.Country.Value)
 
@@ -64,7 +64,7 @@ func TestProxyCreate_Datacenter_WithoutCountry(t *testing.T) {
 			assert.Equal(t, "My DC Proxy", body.Name.Value)
 
 			// Check config - country should not be set (it should be zero/nil)
-			dcConfig := body.Config.OfProxyNewsConfigDatacenterProxyConfig
+			dcConfig := body.Config.OfDatacenter
 			assert.NotNil(t, dcConfig)
 
 			return &kernel.ProxyNewResponse{
@@ -94,7 +94,7 @@ func TestProxyCreate_Residential_Success(t *testing.T) {
 	fake := &FakeProxyService{
 		NewFunc: func(ctx context.Context, body kernel.ProxyNewParams, opts ...option.RequestOption) (*kernel.ProxyNewResponse, error) {
 			// Verify residential config
-			resConfig := body.Config.OfProxyNewsConfigResidentialProxyConfig
+			resConfig := body.Config.OfResidential
 			assert.NotNil(t, resConfig)
 			assert.Equal(t, "US", resConfig.Country.Value)
 			assert.Equal(t, "sanfrancisco", resConfig.City.Value)
@@ -161,10 +161,10 @@ func TestProxyCreate_Mobile_Success(t *testing.T) {
 	fake := &FakeProxyService{
 		NewFunc: func(ctx context.Context, body kernel.ProxyNewParams, opts ...option.RequestOption) (*kernel.ProxyNewResponse, error) {
 			// Verify mobile config
-			mobConfig := body.Config.OfProxyNewsConfigMobileProxyConfig
+			mobConfig := body.Config.OfMobile
 			assert.NotNil(t, mobConfig)
 			assert.Equal(t, "US", mobConfig.Country.Value)
-			assert.Equal(t, "verizon", mobConfig.Carrier)
+			assert.Equal(t, "newyork", mobConfig.City.Value)
 
 			return &kernel.ProxyNewResponse{
 				ID:   "mobile-new",
@@ -179,7 +179,7 @@ func TestProxyCreate_Mobile_Success(t *testing.T) {
 		Name:    "Mobile Proxy",
 		Type:    "mobile",
 		Country: "US",
-		Carrier: "verizon",
+		City:    "newyork",
 	})
 
 	assert.NoError(t, err)
@@ -194,7 +194,7 @@ func TestProxyCreate_Custom_Success(t *testing.T) {
 	fake := &FakeProxyService{
 		NewFunc: func(ctx context.Context, body kernel.ProxyNewParams, opts ...option.RequestOption) (*kernel.ProxyNewResponse, error) {
 			// Verify custom config
-			customConfig := body.Config.OfProxyNewsConfigCreateCustomProxyConfig
+			customConfig := body.Config.OfCustom
 			assert.NotNil(t, customConfig)
 			assert.Equal(t, "proxy.example.com", customConfig.Host)
 			assert.Equal(t, int64(8080), customConfig.Port)
@@ -359,7 +359,7 @@ func TestProxyCreate_ISP_Success(t *testing.T) {
 	fake := &FakeProxyService{
 		NewFunc: func(ctx context.Context, body kernel.ProxyNewParams, opts ...option.RequestOption) (*kernel.ProxyNewResponse, error) {
 			// Verify ISP config
-			ispConfig := body.Config.OfProxyNewsConfigIspProxyConfig
+			ispConfig := body.Config.OfIsp
 			assert.NotNil(t, ispConfig)
 			assert.Equal(t, "EU", ispConfig.Country.Value)
 
@@ -390,7 +390,7 @@ func TestProxyCreate_ISP_WithoutCountry(t *testing.T) {
 	fake := &FakeProxyService{
 		NewFunc: func(ctx context.Context, body kernel.ProxyNewParams, opts ...option.RequestOption) (*kernel.ProxyNewResponse, error) {
 			// Verify ISP config
-			ispConfig := body.Config.OfProxyNewsConfigIspProxyConfig
+			ispConfig := body.Config.OfIsp
 			assert.NotNil(t, ispConfig)
 
 			return &kernel.ProxyNewResponse{

--- a/cmd/proxies/get.go
+++ b/cmd/proxies/get.go
@@ -111,9 +111,6 @@ func getProxyConfigRows(proxy *kernel.ProxyGetResponse) [][]string {
 		if config.Asn != "" {
 			rows = append(rows, []string{"ASN", config.Asn})
 		}
-		if config.Carrier != "" {
-			rows = append(rows, []string{"Carrier", config.Carrier})
-		}
 	case kernel.ProxyGetResponseTypeCustom:
 		if config.Host != "" {
 			rows = append(rows, []string{"Host", config.Host})

--- a/cmd/proxies/get_test.go
+++ b/cmd/proxies/get_test.go
@@ -101,7 +101,7 @@ func TestProxyGet_Mobile(t *testing.T) {
 				Type: kernel.ProxyGetResponseTypeMobile,
 				Config: kernel.ProxyGetResponseConfigUnion{
 					Country: "US",
-					Carrier: "verizon",
+					City:    "newyork",
 				},
 			}, nil
 		},
@@ -113,8 +113,8 @@ func TestProxyGet_Mobile(t *testing.T) {
 	assert.NoError(t, err)
 	output := buf.String()
 
-	assert.Contains(t, output, "Carrier")
-	assert.Contains(t, output, "verizon")
+	assert.Contains(t, output, "City")
+	assert.Contains(t, output, "newyork")
 }
 
 func TestProxyGet_Custom(t *testing.T) {

--- a/cmd/proxies/list.go
+++ b/cmd/proxies/list.go
@@ -21,20 +21,25 @@ func (p ProxyCmd) List(ctx context.Context, in ProxyListInput) error {
 		pterm.Info.Println("Fetching proxy configurations...")
 	}
 
-	items, err := p.proxies.List(ctx)
+	page, err := p.proxies.List(ctx, kernel.ProxyListParams{})
 	if err != nil {
 		return util.CleanedUpSdkError{Err: err}
 	}
 
+	var items []kernel.ProxyListResponse
+	if page != nil {
+		items = page.Items
+	}
+
 	if in.Output == "json" {
-		if items == nil || len(*items) == 0 {
+		if len(items) == 0 {
 			fmt.Println("[]")
 			return nil
 		}
-		return util.PrintPrettyJSONSlice(*items)
+		return util.PrintPrettyJSONSlice(items)
 	}
 
-	if items == nil || len(*items) == 0 {
+	if len(items) == 0 {
 		pterm.Info.Println("No proxy configurations found")
 		return nil
 	}
@@ -44,7 +49,7 @@ func (p ProxyCmd) List(ctx context.Context, in ProxyListInput) error {
 		{"ID", "Name", "Type", "Protocol", "Bypass Hosts", "Config", "Status", "Last Checked"},
 	}
 
-	for _, proxy := range *items {
+	for _, proxy := range items {
 		name := proxy.Name
 		if name == "" {
 			name = "-"
@@ -114,8 +119,8 @@ func formatProxyConfig(proxy *kernel.ProxyListResponse) string {
 		if config.Country != "" {
 			parts = append(parts, fmt.Sprintf("Country: %s", config.Country))
 		}
-		if config.Carrier != "" {
-			parts = append(parts, fmt.Sprintf("Carrier: %s", config.Carrier))
+		if config.City != "" {
+			parts = append(parts, fmt.Sprintf("City: %s", config.City))
 		}
 		if len(parts) > 0 {
 			return strings.Join(parts, ", ")

--- a/cmd/proxies/list_test.go
+++ b/cmd/proxies/list_test.go
@@ -7,15 +7,15 @@ import (
 
 	"github.com/kernel/kernel-go-sdk"
 	"github.com/kernel/kernel-go-sdk/option"
+	"github.com/kernel/kernel-go-sdk/packages/pagination"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestProxyList_Empty(t *testing.T) {
 	buf := captureOutput(t)
 	fake := &FakeProxyService{
-		ListFunc: func(ctx context.Context, opts ...option.RequestOption) (*[]kernel.ProxyListResponse, error) {
-			empty := []kernel.ProxyListResponse{}
-			return &empty, nil
+		ListFunc: func(ctx context.Context, query kernel.ProxyListParams, opts ...option.RequestOption) (*pagination.OffsetPagination[kernel.ProxyListResponse], error) {
+			return proxyListPage(nil), nil
 		},
 	}
 
@@ -40,7 +40,7 @@ func TestProxyList_WithProxies(t *testing.T) {
 			BypassHosts: []string{"abc"},
 			Config: kernel.ProxyListResponseConfigUnion{
 				Country: "US",
-				Carrier: "verizon",
+				City:    "newyork",
 			},
 		},
 		{
@@ -54,8 +54,8 @@ func TestProxyList_WithProxies(t *testing.T) {
 	}
 
 	fake := &FakeProxyService{
-		ListFunc: func(ctx context.Context, opts ...option.RequestOption) (*[]kernel.ProxyListResponse, error) {
-			return &proxies, nil
+		ListFunc: func(ctx context.Context, query kernel.ProxyListParams, opts ...option.RequestOption) (*pagination.OffsetPagination[kernel.ProxyListResponse], error) {
+			return proxyListPage(proxies), nil
 		},
 	}
 
@@ -97,7 +97,7 @@ func TestProxyList_Error(t *testing.T) {
 	_ = captureOutput(t)
 
 	fake := &FakeProxyService{
-		ListFunc: func(ctx context.Context, opts ...option.RequestOption) (*[]kernel.ProxyListResponse, error) {
+		ListFunc: func(ctx context.Context, query kernel.ProxyListParams, opts ...option.RequestOption) (*pagination.OffsetPagination[kernel.ProxyListResponse], error) {
 			return nil, errors.New("API error")
 		},
 	}

--- a/cmd/proxies/proxies.go
+++ b/cmd/proxies/proxies.go
@@ -100,9 +100,6 @@ func init() {
 	// OS flag (residential)
 	proxiesCreateCmd.Flags().String("os", "", "Operating system (windows|macos|android)")
 
-	// Carrier flag (mobile)
-	proxiesCreateCmd.Flags().String("carrier", "", "Mobile carrier (see help for full list)")
-
 	// Custom proxy flags
 	proxiesCreateCmd.Flags().String("host", "", "Proxy host address or IP")
 	proxiesCreateCmd.Flags().Int("port", 0, "Proxy port")

--- a/cmd/proxies/types.go
+++ b/cmd/proxies/types.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/kernel/kernel-go-sdk"
 	"github.com/kernel/kernel-go-sdk/option"
+	"github.com/kernel/kernel-go-sdk/packages/pagination"
 )
 
 // ProxyService defines the subset of the Kernel SDK proxy client that we use.
 type ProxyService interface {
-	List(ctx context.Context, opts ...option.RequestOption) (res *[]kernel.ProxyListResponse, err error)
+	List(ctx context.Context, query kernel.ProxyListParams, opts ...option.RequestOption) (res *pagination.OffsetPagination[kernel.ProxyListResponse], err error)
 	Get(ctx context.Context, id string, opts ...option.RequestOption) (res *kernel.ProxyGetResponse, err error)
 	New(ctx context.Context, body kernel.ProxyNewParams, opts ...option.RequestOption) (res *kernel.ProxyNewResponse, err error)
 	Delete(ctx context.Context, id string, opts ...option.RequestOption) (err error)
@@ -45,8 +46,6 @@ type ProxyCreateInput struct {
 	Zip   string
 	ASN   string
 	OS    string
-	// Mobile specific
-	Carrier string
 	// Custom proxy config
 	Host     string
 	Port     int

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.1
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/joho/godotenv v1.5.1
-	github.com/kernel/kernel-go-sdk v0.58.0
+	github.com/kernel/kernel-go-sdk v0.64.0
 	github.com/klauspost/compress v1.18.5
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pterm/pterm v0.12.80

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
-github.com/kernel/kernel-go-sdk v0.58.0 h1:FcvqZXgK5D3IbHJarvRJVPJpKE3+Pd7i4z4kBgElpIk=
-github.com/kernel/kernel-go-sdk v0.58.0/go.mod h1:EeZzSuHZVeHKxKCPUzxou2bovNGhXaz0RXrSqKNf1AQ=
+github.com/kernel/kernel-go-sdk v0.64.0 h1:pmBAbz9c1DU7f5KYz1S0M093awl/y+qnDBwdIPBGxUs=
+github.com/kernel/kernel-go-sdk v0.64.0/go.mod h1:EeZzSuHZVeHKxKCPUzxou2bovNGhXaz0RXrSqKNf1AQ=
 github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
 github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=


### PR DESCRIPTION
## Summary

Prerequisite for the telemetry opt-in CLI change (`sayan/kernel-1342-switch-to-opt-in-for-categories`), which needs the telemetry category params introduced in the newer SDK. Bumping `kernel-go-sdk` from v0.58.0 to v0.64.0 pulls in unrelated breaking API changes that have to be absorbed first.

The bump breaks more than proxies (Go's build had been stopping at the proxies dependency, masking the rest). Every `List` consumer and the proxy config unions needed migrating:

- **Paginated `List`**: `List` now takes a `*ListParams` and returns `*pagination.OffsetPagination[T]` instead of `*[]T`. Migrated the local service interfaces, call sites, and test fakes for `proxies`, `browser_pools`, `credential_providers`, and `extensions` to pass `ListParams{}` and read `page.Items`.
- **Proxy create config union**: renamed union fields/types to the new names (`OfDatacenter`, `OfIsp`, `OfResidential`, `OfMobile`, `OfCustom` / `ProxyNewParamsConfigDatacenter`, etc.).
- **`BrowserPoolUpdateParams.Size`** is now an optional `int64` (`kernel.Int(...)`).
- **Mobile proxy + responses dropped `carrier`** (also `zip`/`asn` on mobile request config, and `carrier` on the check/get/list responses). Removed the now-dead `--carrier` flag and the carrier display rows.

## Behavior notes

- `--carrier` is removed because the API no longer accepts or returns it. `--zip`/`--asn` remain (still valid for residential); they're silently ignored for mobile now, matching the API.
- `list` commands still do a single `List` call and render the returned page, preserving the prior single-call behavior (no auto-paging change). If we want `list` to page through everything, that's a separate follow-up.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (all green)
- [x] `go vet ./...`, `gofmt -l`, `go mod tidy` clean
- [ ] Smoke test `kernel proxies list/create/get/check`, `kernel browser-pools list`, `kernel extensions list`, `kernel credential-providers list` against prod

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide CLI/SDK contract changes (list pagination, proxy create payloads, removed `--carrier`) can surprise users and truncate results if the API default page size is smaller than a full account list; core auth paths are untouched.
> 
> **Overview**
> Bumps **`kernel-go-sdk`** from **v0.58.0** to **v0.64.0** so follow-up work (e.g. telemetry category params) can land on the newer client.
> 
> **Paginated `List`:** Service interfaces and handlers for **browser pools**, **credential providers**, **extensions**, and **proxies** now call `List` with empty `*ListParams` and read **`page.Items`** from `*pagination.OffsetPagination[T]` instead of `*[]T`. Test fakes were updated the same way. List commands still perform a **single** list request (no multi-page iteration).
> 
> **Proxy SDK shape:** `proxies create` uses renamed config union fields (`OfDatacenter`, `OfIsp`, `OfResidential`, `OfMobile`, `OfCustom`) and matching config types.
> 
> **Other SDK fixes:** `browser-pools update` sets pool **size** via `kernel.Int(...)`.
> 
> **Mobile proxy CLI:** Removes **`--carrier`** and carrier display on get/check/list; mobile create no longer sends zip/asn/carrier on the mobile config. Mobile list/get display emphasizes **city** where carrier used to appear.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a02df964bb347e918e7f368d678f2f0f7b5854b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->