### PR TITLE
ci: enable Cursor Max Mode for cursor-agent workflow

### DIFF
--- a/.github/workflows/fix-ci.yaml
+++ b/.github/workflows/fix-ci.yaml
@@ -36,6 +36,13 @@ jobs:
           curl https://cursor.com/install -fsS | bash
           echo "$HOME/.cursor/bin" >> $GITHUB_PATH
 
+      - name: Enable Cursor Max Mode
+        run: |
+          CFG_DIR="$HOME/.cursor"
+          mkdir -p "$CFG_DIR"
+          echo '{"maxMode": true}' > "$CFG_DIR/cli-config.json"
+          echo "CURSOR_CONFIG_DIR=$CFG_DIR" >> "$GITHUB_ENV"
+
       - name: Configure git identity
         run: |
           git config user.name "kernel-internal[bot]"


### PR DESCRIPTION
## Summary

The `fix-ci.yaml` workflow invokes `cursor-agent` with `--model ${{ vars.CURSOR_PREFERRED_MODEL }}` (`claude-opus-4-8-xhigh`), which requires Cursor **Max Mode**. CI was failing with `Max Mode Required`.

A fresh `cursor-agent` install defaults to `maxMode=false`, and the setting must be persisted to the CLI config file. On GitHub-hosted runners, `XDG_CONFIG_HOME=/home/runner/.config`, and cursor-agent resolves its config dir as `CURSOR_CONFIG_DIR || $XDG_CONFIG_HOME/cursor || ~/.cursor`. So writing `~/.cursor/cli-config.json` alone is ignored unless `CURSOR_CONFIG_DIR` is also pinned.

## Fix

Adds an `Enable Cursor Max Mode` step immediately after the Cursor CLI install step:
- Writes `{"maxMode": true}` to `cli-config.json`.
- Pins `CURSOR_CONFIG_DIR` via `$GITHUB_ENV` so the agent step reads the right config.

## Note

This also requires the `CURSOR_API_KEY` account to be Max-Mode entitled.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow configuration with no application or security logic changes; depends on Max Mode entitlement for the API key.
> 
> **Overview**
> The **Fix CI Failures** workflow now turns on Cursor **Max Mode** right after installing the Cursor CLI so `cursor-agent` can run with the configured high-tier model (`CURSOR_PREFERRED_MODEL`) without hitting **Max Mode Required**.
> 
> The new step writes `{"maxMode": true}` to `cli-config.json` under `$HOME/.cursor` and sets **`CURSOR_CONFIG_DIR`** in `$GITHUB_ENV`, so the agent step picks up that config on GitHub-hosted runners (where the default XDG config path would otherwise ignore `~/.cursor` alone).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49e671117ac54c307a4ace8d54fc9e992b8b3e4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->