### PR TITLE
Fix --telemetry help text to match update merge semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,14 +300,14 @@ Commands with JSON output support:
 
 Telemetry config is a sub-field of the browser session. Use `browsers create` or `browsers update` to enable, disable, or configure it, and `browsers get` to inspect the current state.
 
-- Enable all categories: `kernel browsers update <id> --telemetry=all`
+- Enable the default set: `kernel browsers update <id> --telemetry=all`
 - Disable: `kernel browsers update <id> --telemetry=off`
-- Per-category: `kernel browsers update <id> --telemetry=network=on,page=off` (valid: `console`, `interaction`, `network`, `page`; `system` always emits and cannot be toggled)
+- Capture specific categories: `kernel browsers update <id> --telemetry=console,network` (any of: `console`, `network`, `page`, `interaction`, `control`, `connection`, `system`, `screenshot`, `captcha`)
 
 Per-category updates are partial — only categories you name are changed; others retain their current state. `--telemetry=all` and `--telemetry=off` reset the entire config.
 
 - `kernel browsers telemetry stream <id>` - Stream live telemetry events (NDJSON with `-o json`)
-  - `--categories <list>` - Filter by event category (`api`, `console`, `interaction`, `network`, `page`, `system`); `system` matches `monitor_*` and `cdp_*` event types
+  - `--categories <list>` - Filter by event category (`console`, `network`, `page`, `interaction`, `control`, `connection`, `system`, `screenshot`, `captcha`, `monitor`)
   - `--types <list>` - Filter by event type (e.g. `network_response`, `console_error`)
   - `--seq <n>` - Resume after sequence number N (Last-Event-ID); replays events with `seq > N`. Omit to stream from now.
   - `-o, --output json` - Output newline-delimited JSON envelopes

--- a/cmd/browsers.go
+++ b/cmd/browsers.go
@@ -2331,7 +2331,7 @@ func init() {
 	browsersUpdateCmd.Flags().Bool("save-changes", false, "If set, save changes back to the profile when the session ends")
 	browsersUpdateCmd.Flags().String("viewport", "", "Browser viewport size (e.g., 1920x1080@25). Supported: 2560x1440@10, 1920x1080@25, 1920x1200@25, 1440x900@25, 1024x768@60, 1200x800@60, 1280x800@60")
 	browsersUpdateCmd.Flags().Bool("force", false, "Force viewport resize even when a live view or recording/replay is active")
-	browsersUpdateCmd.Flags().String("telemetry", "", "Update telemetry (opt-in, replaces current selection): --telemetry=all (default set), --telemetry=off (disable), or --telemetry=console,network (capture exactly those categories)")
+	browsersUpdateCmd.Flags().String("telemetry", "", "Update telemetry: --telemetry=all (reset to default set), --telemetry=off (disable), or --telemetry=console,network (merge those categories into the current selection)")
 
 	browsersCmd.AddCommand(browsersListCmd)
 	browsersCmd.AddCommand(browsersCreateCmd)


### PR DESCRIPTION
## Summary
The telemetry CLI help and README still described the old/incorrect contract. A per-category telemetry `update` merges into the session's current selection (only categories you name change); only `--telemetry=all`/`off` reset the whole config.

Docs-only/help-text; no behavior change.

## Test plan

CI


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CLI flag help text only; no code paths or API behavior changed.
> 
> **Overview**
> **Docs-only** alignment for browser telemetry on `browsers update` and in the README—no runtime changes.
> 
> The `--telemetry` flag help on `kernel browsers update` now states that `--telemetry=all` **resets to the default set**, `--telemetry=off` disables, and comma-separated categories **merge into the current selection** (instead of replacing the whole config).
> 
> The README **Browser Telemetry** section is updated the same way: clearer examples for default/on/off and per-category capture, plus an expanded `--categories` list for `telemetry stream` (`control`, `connection`, `screenshot`, `captcha`, `monitor`, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e66b2f7807c6012c769fa8a9091ad601c9fabe51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->