### PR TITLE
ci: bump actions to Node 24 runtime versions

### DIFF
--- a/.github/workflows/fix-ci.yaml
+++ b/.github/workflows/fix-ci.yaml
@@ -20,13 +20,13 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.ADMIN_APP_ID }}
           private-key: ${{ secrets.ADMIN_APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
@@ -49,7 +49,7 @@ jobs:
           git config user.email "260533166+kernel-internal[bot]@users.noreply.github.com"
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,25 +15,25 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.ADMIN_APP_ID }}
           private-key: ${{ secrets.ADMIN_APP_PRIVATE_KEY }}
           repositories: cli,homebrew-tap
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
           cache: true
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
@@ -45,7 +45,7 @@ jobs:
         run: make clean-templates
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser-pro
           version: '~> v2'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
           cache: true


### PR DESCRIPTION
## Summary
GitHub forces JS actions onto Node 24 on 2026-06-16 (Node 20 removed 2026-09-16). Bump the pinned actions across the three workflows that use them to their Node 24 majors:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-go` | v5 | v6 |
| `actions/setup-node` | v4 | v6 |
| `actions/create-github-app-token` | v1 | v3 |
| `goreleaser/goreleaser-action` | v6 | v7 |

`create-github-app-token` inputs (`app-id`/`private-key`/`repositories`) and `goreleaser-action` inputs are unchanged across these majors (goreleaser-action v7 is a runtime-only bump). GitHub-hosted runners already meet the v2.327.1 minimum.

## Validation
- `test.yaml` runs on `pull_request`, so the `checkout` + `setup-go` bumps are exercised by this PR's check run.
- `release.yaml` only runs on a `v*` tag, so its bumps (`goreleaser-action`, `setup-node`, release-path `create-github-app-token`/`checkout`) are **not** exercised here — they'll be confirmed on the next release.
- `fix-ci.yaml` is a `workflow_run` workflow (runs from the default branch), so its bumps take effect after merge.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only version pin updates with no application or secret-handling logic changes; release and fix-ci bumps are not fully exercised until tag push and merge.
> 
> **Overview**
> Bumps pinned GitHub Actions in **fix-ci**, **release**, and **test** workflows to majors that run on **Node 24**, ahead of GitHub’s deprecation of Node 20 for JS actions.
> 
> **test.yaml** and **fix-ci.yaml** move `actions/checkout` to **v6** and `actions/setup-go` to **v6**; **fix-ci** and **release** also bump `actions/create-github-app-token` to **v3**. **release.yaml** additionally upgrades `actions/setup-node` to **v6** and `goreleaser/goreleaser-action` to **v7**. Step inputs (`app-id`, `private-key`, `go-version-file`, GoReleaser args, etc.) are unchanged.
> 
> This PR’s CI run exercises the **test** workflow bumps; **release** and post-merge **fix-ci** paths are validated on tag push and default-branch workflow runs respectively.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8e487490694d5292604297bd2dc1ec947fedebe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->