### PR TITLE
Add --replay-all to browsers telemetry stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ Per-category updates are partial — only categories you name are changed; other
   - `--categories <list>` - Filter by event category (`console`, `network`, `page`, `interaction`, `control`, `connection`, `system`, `screenshot`, `captcha`, `monitor`)
   - `--types <list>` - Filter by event type (e.g. `network_response`, `console_error`)
   - `--seq <n>` - Resume after sequence number N (Last-Event-ID); replays events with `seq > N`. Omit to stream from now.
+  - `--replay-all` - Replay from the oldest retained event instead of streaming from now. Mutually exclusive with `--seq`. The buffer is bounded, so the first event may not be `seq 1` if older events were evicted.
   - `-o, --output json` - Output newline-delimited JSON envelopes
   - Default output: tab-separated `<time>\t[<category>]\t<type>`, e.g. `15:04:05  [network]  network_response`
 

--- a/cmd/api_keys.go
+++ b/cmd/api_keys.go
@@ -14,7 +14,7 @@ import (
 
 type APIKeysService interface {
 	New(ctx context.Context, body kernel.APIKeyNewParams, opts ...option.RequestOption) (*kernel.CreatedAPIKey, error)
-	Get(ctx context.Context, id string, opts ...option.RequestOption) (*kernel.APIKey, error)
+	Get(ctx context.Context, id string, query kernel.APIKeyGetParams, opts ...option.RequestOption) (*kernel.APIKey, error)
 	Update(ctx context.Context, id string, body kernel.APIKeyUpdateParams, opts ...option.RequestOption) (*kernel.APIKey, error)
 	List(ctx context.Context, query kernel.APIKeyListParams, opts ...option.RequestOption) (*pagination.OffsetPagination[kernel.APIKey], error)
 	Delete(ctx context.Context, id string, opts ...option.RequestOption) error
@@ -145,7 +145,7 @@ func (c APIKeysCmd) Get(ctx context.Context, in APIKeysGetInput) error {
 		return err
 	}
 
-	key, err := c.apiKeys.Get(ctx, in.ID)
+	key, err := c.apiKeys.Get(ctx, in.ID, kernel.APIKeyGetParams{})
 	if err != nil {
 		return util.CleanedUpSdkError{Err: err}
 	}

--- a/cmd/api_keys_test.go
+++ b/cmd/api_keys_test.go
@@ -29,7 +29,7 @@ func (f *FakeAPIKeysService) New(ctx context.Context, body kernel.APIKeyNewParam
 	return createdAPIKeyFromJSON(`{"id":"key_123","name":"default","key":"sk_test","masked_key":"sk_...test","created_at":"2026-05-27T12:00:00Z","created_by":{"id":"user_123","email":"dev@example.com","name":"Dev"},"expires_at":null,"project_id":null,"project_name":null}`), nil
 }
 
-func (f *FakeAPIKeysService) Get(ctx context.Context, id string, opts ...option.RequestOption) (*kernel.APIKey, error) {
+func (f *FakeAPIKeysService) Get(ctx context.Context, id string, query kernel.APIKeyGetParams, opts ...option.RequestOption) (*kernel.APIKey, error) {
 	if f.GetFunc != nil {
 		return f.GetFunc(ctx, id, opts...)
 	}

--- a/cmd/browsers.go
+++ b/cmd/browsers.go
@@ -2747,6 +2747,7 @@ followed automatically by Chromium.`,
 	telemetryStream.Flags().StringSlice("categories", []string{}, "Filter by event category (console,network,page,interaction,control,connection,system,screenshot,captcha,monitor)")
 	telemetryStream.Flags().StringSlice("types", []string{}, "Filter by event type (e.g. network_response,console_error)")
 	telemetryStream.Flags().Int64("seq", -1, "Resume after sequence number N (Last-Event-ID); replays events with seq > N. Default -1 streams from now")
+	telemetryStream.Flags().Bool("replay-all", false, "Replay from the oldest retained event instead of streaming from now. Mutually exclusive with --seq")
 	telemetryStream.Flags().StringP("output", "o", "", "Output format: json for newline-delimited JSON envelopes")
 	telemetryRoot.AddCommand(telemetryStream)
 	browsersCmd.AddCommand(telemetryRoot)

--- a/cmd/browsers_telemetry.go
+++ b/cmd/browsers_telemetry.go
@@ -30,6 +30,7 @@ type BrowsersTelemetryStreamInput struct {
 	Categories []string
 	Types      []string
 	Seq        int64
+	ReplayAll  bool
 	Output     string
 }
 
@@ -172,6 +173,9 @@ func (b BrowsersCmd) TelemetryStream(ctx context.Context, in BrowsersTelemetrySt
 	if err := validateJSONOutput(in.Output); err != nil {
 		return err
 	}
+	if in.ReplayAll && in.Seq != -1 {
+		return fmt.Errorf("cannot combine --replay-all with --seq: --replay-all starts from the oldest retained event, --seq resumes after a specific sequence")
+	}
 	if in.Seq != -1 && in.Seq < 1 {
 		return fmt.Errorf("invalid --seq value %d: must be >= 1 (resumes after sequence N; omit --seq to stream from now)", in.Seq)
 	}
@@ -187,8 +191,11 @@ func (b BrowsersCmd) TelemetryStream(ctx context.Context, in BrowsersTelemetrySt
 		return util.CleanedUpSdkError{Err: err}
 	}
 	params := kernel.BrowserTelemetryStreamParams{}
-	if in.Seq >= 0 {
+	switch {
+	case in.Seq >= 0:
 		params.LastEventID = kernel.Opt(strconv.FormatInt(in.Seq, 10))
+	case in.ReplayAll:
+		params.Replay = kernel.Opt("all")
 	}
 	stream := b.telemetry.StreamStreaming(ctx, br.SessionID, params)
 	defer stream.Close()
@@ -223,12 +230,14 @@ func runBrowsersTelemetryStream(cmd *cobra.Command, args []string) error {
 	categories, _ := cmd.Flags().GetStringSlice("categories")
 	types, _ := cmd.Flags().GetStringSlice("types")
 	seq, _ := cmd.Flags().GetInt64("seq")
+	replayAll, _ := cmd.Flags().GetBool("replay-all")
 	b := BrowsersCmd{browsers: &svc, telemetry: &svc.Telemetry}
 	return b.TelemetryStream(cmd.Context(), BrowsersTelemetryStreamInput{
 		Identifier: args[0],
 		Categories: categories,
 		Types:      types,
 		Seq:        seq,
+		ReplayAll:  replayAll,
 		Output:     out,
 	})
 }

--- a/cmd/browsers_telemetry.go
+++ b/cmd/browsers_telemetry.go
@@ -25,6 +25,11 @@ type BrowserTelemetryService interface {
 	StreamStreaming(ctx context.Context, id string, query kernel.BrowserTelemetryStreamParams, opts ...option.RequestOption) (stream *ssestream.Stream[kernel.BrowserTelemetryStreamResponse])
 }
 
+// replayAllValue is the telemetry stream `replay` query value that starts the
+// stream from the oldest retained event. It must match the value the browser
+// image matches on; there is no generated enum tying the two together.
+const replayAllValue = "all"
+
 type BrowsersTelemetryStreamInput struct {
 	Identifier string
 	Categories []string
@@ -195,7 +200,7 @@ func (b BrowsersCmd) TelemetryStream(ctx context.Context, in BrowsersTelemetrySt
 	case in.Seq >= 0:
 		params.LastEventID = kernel.Opt(strconv.FormatInt(in.Seq, 10))
 	case in.ReplayAll:
-		params.Replay = kernel.Opt("all")
+		params.Replay = kernel.Opt(replayAllValue)
 	}
 	stream := b.telemetry.StreamStreaming(ctx, br.SessionID, params)
 	defer stream.Close()

--- a/cmd/browsers_telemetry.go
+++ b/cmd/browsers_telemetry.go
@@ -31,12 +31,13 @@ type BrowserTelemetryService interface {
 const replayAllValue = "all"
 
 type BrowsersTelemetryStreamInput struct {
-	Identifier string
-	Categories []string
-	Types      []string
-	Seq        int64
-	ReplayAll  bool
-	Output     string
+	Identifier  string
+	Categories  []string
+	Types       []string
+	Seq         int64
+	SeqProvided bool
+	ReplayAll   bool
+	Output      string
 }
 
 // parseTelemetryCategories parses a comma-separated list of category names to
@@ -178,7 +179,7 @@ func (b BrowsersCmd) TelemetryStream(ctx context.Context, in BrowsersTelemetrySt
 	if err := validateJSONOutput(in.Output); err != nil {
 		return err
 	}
-	if in.ReplayAll && in.Seq != -1 {
+	if in.ReplayAll && in.SeqProvided {
 		return fmt.Errorf("cannot combine --replay-all with --seq: --replay-all starts from the oldest retained event, --seq resumes after a specific sequence")
 	}
 	if in.Seq != -1 && in.Seq < 1 {
@@ -238,11 +239,12 @@ func runBrowsersTelemetryStream(cmd *cobra.Command, args []string) error {
 	replayAll, _ := cmd.Flags().GetBool("replay-all")
 	b := BrowsersCmd{browsers: &svc, telemetry: &svc.Telemetry}
 	return b.TelemetryStream(cmd.Context(), BrowsersTelemetryStreamInput{
-		Identifier: args[0],
-		Categories: categories,
-		Types:      types,
-		Seq:        seq,
-		ReplayAll:  replayAll,
-		Output:     out,
+		Identifier:  args[0],
+		Categories:  categories,
+		Types:       types,
+		Seq:         seq,
+		SeqProvided: cmd.Flags().Changed("seq"),
+		ReplayAll:   replayAll,
+		Output:      out,
 	})
 }

--- a/cmd/browsers_telemetry_test.go
+++ b/cmd/browsers_telemetry_test.go
@@ -34,9 +34,11 @@ func captureStdout(t *testing.T, fn func()) string {
 
 type FakeBrowserTelemetryService struct {
 	StreamFunc func() *ssestream.Stream[kernel.BrowserTelemetryStreamResponse]
+	LastQuery  kernel.BrowserTelemetryStreamParams
 }
 
 func (f *FakeBrowserTelemetryService) StreamStreaming(ctx context.Context, id string, query kernel.BrowserTelemetryStreamParams, opts ...option.RequestOption) *ssestream.Stream[kernel.BrowserTelemetryStreamResponse] {
+	f.LastQuery = query
 	if f.StreamFunc != nil {
 		return f.StreamFunc()
 	}
@@ -81,6 +83,54 @@ func TestTelemetryStream_NegativeSeqErrors(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid --seq value -2")
+}
+
+func TestTelemetryStream_ReplayAllWithSeqErrors(t *testing.T) {
+	b := BrowsersCmd{browsers: &FakeBrowsersService{}, telemetry: &FakeBrowserTelemetryService{}}
+
+	err := b.TelemetryStream(context.Background(), BrowsersTelemetryStreamInput{
+		Identifier: "session123",
+		Seq:        5,
+		ReplayAll:  true,
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot combine --replay-all with --seq")
+}
+
+func TestTelemetryStream_ReplayAllSetsReplayParam(t *testing.T) {
+	fakeBrowsers := &FakeBrowsersService{GetFunc: func(ctx context.Context, id string, query kernel.BrowserGetParams, opts ...option.RequestOption) (*kernel.BrowserGetResponse, error) {
+		return &kernel.BrowserGetResponse{SessionID: id}, nil
+	}}
+	fakeTelemetry := &FakeBrowserTelemetryService{}
+	b := BrowsersCmd{browsers: fakeBrowsers, telemetry: fakeTelemetry}
+
+	err := b.TelemetryStream(context.Background(), BrowsersTelemetryStreamInput{
+		Identifier: "session123",
+		Seq:        -1,
+		ReplayAll:  true,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "all", fakeTelemetry.LastQuery.Replay.Or(""))
+	assert.False(t, fakeTelemetry.LastQuery.LastEventID.Valid(), "Last-Event-ID must not be set with --replay-all")
+}
+
+func TestTelemetryStream_SeqSetsLastEventID(t *testing.T) {
+	fakeBrowsers := &FakeBrowsersService{GetFunc: func(ctx context.Context, id string, query kernel.BrowserGetParams, opts ...option.RequestOption) (*kernel.BrowserGetResponse, error) {
+		return &kernel.BrowserGetResponse{SessionID: id}, nil
+	}}
+	fakeTelemetry := &FakeBrowserTelemetryService{}
+	b := BrowsersCmd{browsers: fakeBrowsers, telemetry: fakeTelemetry}
+
+	err := b.TelemetryStream(context.Background(), BrowsersTelemetryStreamInput{
+		Identifier: "session123",
+		Seq:        5,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "5", fakeTelemetry.LastQuery.LastEventID.Or(""))
+	assert.False(t, fakeTelemetry.LastQuery.Replay.Valid(), "replay must not be set with --seq")
 }
 
 func TestTelemetryStream_UnsupportedOutputErrors(t *testing.T) {

--- a/cmd/browsers_telemetry_test.go
+++ b/cmd/browsers_telemetry_test.go
@@ -86,16 +86,21 @@ func TestTelemetryStream_NegativeSeqErrors(t *testing.T) {
 }
 
 func TestTelemetryStream_ReplayAllWithSeqErrors(t *testing.T) {
-	b := BrowsersCmd{browsers: &FakeBrowsersService{}, telemetry: &FakeBrowserTelemetryService{}}
+	// Mutual exclusion is based on whether --seq was provided, not its value, so an
+	// explicit --seq=-1 (the unset sentinel) is still rejected alongside --replay-all.
+	for _, seq := range []int64{5, -1} {
+		b := BrowsersCmd{browsers: &FakeBrowsersService{}, telemetry: &FakeBrowserTelemetryService{}}
 
-	err := b.TelemetryStream(context.Background(), BrowsersTelemetryStreamInput{
-		Identifier: "session123",
-		Seq:        5,
-		ReplayAll:  true,
-	})
+		err := b.TelemetryStream(context.Background(), BrowsersTelemetryStreamInput{
+			Identifier:  "session123",
+			Seq:         seq,
+			SeqProvided: true,
+			ReplayAll:   true,
+		})
 
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot combine --replay-all with --seq")
+		assert.Error(t, err, "seq=%d", seq)
+		assert.Contains(t, err.Error(), "cannot combine --replay-all with --seq")
+	}
 }
 
 func TestTelemetryStream_ReplayAllSetsReplayParam(t *testing.T) {
@@ -124,8 +129,9 @@ func TestTelemetryStream_SeqSetsLastEventID(t *testing.T) {
 	b := BrowsersCmd{browsers: fakeBrowsers, telemetry: fakeTelemetry}
 
 	err := b.TelemetryStream(context.Background(), BrowsersTelemetryStreamInput{
-		Identifier: "session123",
-		Seq:        5,
+		Identifier:  "session123",
+		Seq:         5,
+		SeqProvided: true,
 	})
 
 	assert.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.1
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/joho/godotenv v1.5.1
-	github.com/kernel/kernel-go-sdk v0.66.0
+	github.com/kernel/kernel-go-sdk v0.70.0
 	github.com/klauspost/compress v1.18.5
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pterm/pterm v0.12.80

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
-github.com/kernel/kernel-go-sdk v0.66.0 h1:pn+fSHHo4fJ4kYm8uOkF5J2rj6k1FC6NqlLzoxy2jy4=
-github.com/kernel/kernel-go-sdk v0.66.0/go.mod h1:EeZzSuHZVeHKxKCPUzxou2bovNGhXaz0RXrSqKNf1AQ=
+github.com/kernel/kernel-go-sdk v0.70.0 h1:tgg8suA8R9Y4ZLiby0jNc0KJ1KqHpqg+a4l0sJkZJVM=
+github.com/kernel/kernel-go-sdk v0.70.0/go.mod h1:EeZzSuHZVeHKxKCPUzxou2bovNGhXaz0RXrSqKNf1AQ=
 github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
 github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=


### PR DESCRIPTION
## Summary

Adds `--replay-all` to `kernel browsers telemetry stream <id>`, the CLI surface for telemetry replay-from-oldest. When set, it forwards `replay=all` so the stream starts from the oldest retained ring-buffer event instead of from-now.

- New `--replay-all` bool flag, mutually exclusive with `--seq` (one starts from the oldest retained event, the other resumes after a specific sequence).
- Param wiring: `--seq` -> `Last-Event-ID`, `--replay-all` -> `replay=all` (named constant `replayAllValue`, since the wire value is shared with the browser image with no generated enum tying them).
- Tests assert the param the SDK receives (replay set / not set, LEI set / not set) and the mutual-exclusion error.
- Bumps `kernel-go-sdk` to v0.70.0 (exposes the `Replay` param). The bump also required a small unrelated adaptation to `APIKeyService.Get` (gained a params arg), kept as its own commit.
- README updated.

Sequencing (KERNEL-1351): kernel-images replay (shipped) -> kernel/kernel #2381 (merged + deployed) -> kernel-go-sdk v0.70.0 (published) -> this PR.

## Test plan

- [x] `go build ./...` + `go test ./cmd/...` green (SDK bumped to v0.70.0)
- [x] Flag/validation edge cases on the built binary
- [x] Live end-to-end against prod (created a telemetry browser, exercised all three modes, deleted it)

### Live test results

Built `bin/kernel` at `kernel-go-sdk v0.70.0` and ran against production.

Flag / validation (these fire before any network call):

| case | result |
| --- | --- |
| `--help` | shows `--replay-all` |
| `--replay-all --seq 5` | mutual-exclusion error |
| `--replay-all --seq 0` | mutual-exclusion error fires before the seq<1 check |
| `--seq -2` / `--seq 0` | "invalid --seq value" |
| `--categories bogus` | invalid-category error |
| `-o yaml` | unsupported-output error |

Live end-to-end (created a headless browser with `--telemetry all`, generated ~7 `api_call` events, then deleted the browser):

| test | observed | expected |
| --- | --- | --- |
| `--replay-all` | 7 frames starting at `seq 1` | replay from oldest |
| `--seq 3` | frames `seq 4 -> 8` | resume after N |
| from-now (no flags) | only `seq 10` (the post-connect event), not 1-7 | no replay |

Not exercised live: eviction (replay-all's first `seq` > 1 once the 1024-event ring overflows) needs >1024 events; it is pure server behavior, already verified server-side, and the CLI just prints whatever frames the server returns.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI flag wiring, SDK bump, and docs/tests only; replay behavior is server-side and API keys get uses an empty params struct.
> 
> **Overview**
> Adds **`--replay-all`** to `kernel browsers telemetry stream`, so the CLI can start from the **oldest retained** telemetry event instead of only live / `--seq` resume. With `--replay-all`, the stream sends SDK param **`replay=all`** (via `replayAllValue`); **`--seq`** still maps to **Last-Event-ID**. The two modes are **mutually exclusive** when `--seq` was explicitly passed (`SeqProvided`), including `--seq=-1`.
> 
> **`kernel-go-sdk`** is bumped to **v0.70.0** for the `Replay` stream param. **`api-keys get`** is updated to pass **`APIKeyGetParams{}`** on the new `Get` signature. README documents the flag and bounded-buffer caveat. Tests cover param wiring and the mutual-exclusion error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee9db08d9913a33bbfb9f00ebb70feefd7513fc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->