### PR TITLE
ci: pin release to Node 24 LTS, drop npm@latest self-update (fixes sigstore publish failure)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Ensure latest npm (>= 11.5.1 for OIDC)


### PR DESCRIPTION
## Summary

The `Release CLI` workflow has been failing on the npm publish of `@onkernel/cli`. This supersedes the interim Node bump in #196.

### What was happening

1. `node-version: 'latest'` resolved to **Node 26.5.0** (a non-LTS "Current" release).
2. `npm install -g npm@latest` upgraded the global npm to **12.0.0**.
3. GoReleaser ran `npm publish` with provenance (required for OIDC trusted publishing), and npm 12 fails to resolve its bundled `sigstore` module:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'sigstore'
npm error - .../node_modules/npm/node_modules/libnpmpublish/lib/provenance.js
```

This is a current npm bug: [npm/cli#9722](https://github.com/npm/cli/issues/9722). The GitHub release published, but the npm publish failed.

### Fix

- Pin `node-version` to **`24`** (LTS). Node 24 bundles npm ≥ 11.5.1, which is the documented known-good version for npm OIDC trusted publishing and has working provenance/sigstore.
- Drop the `npm install -g npm@latest` step — it's redundant on Node 24 and was the source of the broken npm 12.

### Note on re-releasing

Tag-triggered runs use the workflow file **at the tagged commit**. After this merges, re-cut the release tag on updated `main` (delete + re-push `v0.21.0`, or tag a fresh commit) so the release runs with the fixed workflow.

Also note the earlier v0.21.0 attempt already created the GitHub release + git tag; that may need cleaning up before re-running so GoReleaser doesn't trip on an existing release.

## Testing

Can't exercise the publish path without pushing a tag. Fix is based on npm/cli#9722 (npm 12 sigstore regression) and the documented Node 24 LTS trusted-publishing baseline.