### PR TITLE
Bump node-version to 24.x in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-node-version: '24.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Ensure latest npm (>= 11.5.1 for OIDC)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 'latest'
+node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Ensure latest npm (>= 11.5.1 for OIDC)


### PR DESCRIPTION
# Summary
Using 24.x (the upcoming LTS) instead of 'latest' which resolved to Node 26 and broke npm publish due to a missing sigstore module.