### PR TITLE
Make audit log end dates exclusive

### DIFF
--- a/cmd/audit_logs.go
+++ b/cmd/audit_logs.go
@@ -49,21 +49,16 @@ func (c AuditLogsCmd) Search(ctx context.Context, in AuditLogsSearchInput) error
 	var err error
 	start := time.Now().UTC().Add(-24 * time.Hour)
 	if in.Start != "" {
-		start, _, err = parseAuditLogTime(in.Start)
+		start, err = parseAuditLogTime(in.Start)
 		if err != nil {
 			return fmt.Errorf("--start: %w", err)
 		}
 	}
 	end := time.Now().UTC()
 	if in.End != "" {
-		var dateOnly bool
-		end, dateOnly, err = parseAuditLogTime(in.End)
+		end, err = parseAuditLogTime(in.End)
 		if err != nil {
 			return fmt.Errorf("--end: %w", err)
-		}
-		// End is exclusive; a date-only end means the whole of that day.
-		if dateOnly {
-			end = end.Add(24 * time.Hour)
 		}
 	}
 	if !start.Before(end) {
@@ -164,14 +159,14 @@ func peekForMore(pager *pagination.PageTokenPaginationAutoPager[kernel.AuditLogE
 	return true
 }
 
-func parseAuditLogTime(value string) (t time.Time, dateOnly bool, err error) {
+func parseAuditLogTime(value string) (time.Time, error) {
 	if t, err := time.Parse(time.RFC3339, value); err == nil {
-		return t, false, nil
+		return t, nil
 	}
 	if t, err := time.Parse("2006-01-02", value); err == nil {
-		return t, true, nil
+		return t, nil
 	}
-	return time.Time{}, false, fmt.Errorf("invalid time %q (expected RFC3339 like 2026-07-01T15:04:05Z or a date like 2026-07-01)", value)
+	return time.Time{}, fmt.Errorf("invalid time %q (expected RFC3339 like 2026-07-01T15:04:05Z or a date like 2026-07-01)", value)
 }
 
 func formatAuditLogUser(entry kernel.AuditLogEntry) string {
@@ -238,7 +233,7 @@ var auditLogsSearchCmd = &cobra.Command{
 func init() {
 	addJSONOutputFlag(auditLogsSearchCmd)
 	auditLogsSearchCmd.Flags().String("start", "", "Start of the search window, RFC3339 or YYYY-MM-DD (default: 24 hours ago)")
-	auditLogsSearchCmd.Flags().String("end", "", "End of the search window, RFC3339 or YYYY-MM-DD inclusive (default: now)")
+	auditLogsSearchCmd.Flags().String("end", "", "Exclusive end of the search window, RFC3339 or YYYY-MM-DD (default: now)")
 	auditLogsSearchCmd.Flags().String("search", "", "Free-text search")
 	auditLogsSearchCmd.Flags().String("method", "", "Filter by HTTP method (e.g. GET)")
 	auditLogsSearchCmd.Flags().String("exclude-method", "", "Exclude an HTTP method")

--- a/cmd/audit_logs_test.go
+++ b/cmd/audit_logs_test.go
@@ -124,18 +124,18 @@ func TestAuditLogsSearchDefaultsWindowToLast24Hours(t *testing.T) {
 	assert.WithinDuration(t, time.Now().UTC(), gotEnd, time.Minute)
 }
 
-func TestAuditLogsSearchDateOnlyEndCoversWholeDay(t *testing.T) {
+func TestAuditLogsSearchDateOnlyEndIsExclusive(t *testing.T) {
 	capturePtermOutput(t)
 	fake := &FakeAuditLogsService{
 		ListAutoPagingFunc: func(ctx context.Context, query kernel.AuditLogListParams, opts ...option.RequestOption) *pagination.PageTokenPaginationAutoPager[kernel.AuditLogEntry] {
-			assert.Equal(t, time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), query.Start)
-			assert.Equal(t, time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC), query.End)
+			assert.Equal(t, time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC), query.Start)
+			assert.Equal(t, time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC), query.End)
 			return auditLogPager()
 		},
 	}
 	c := AuditLogsCmd{auditLogs: fake}
 
-	err := c.Search(context.Background(), AuditLogsSearchInput{Start: "2026-07-01", End: "2026-07-01", Limit: 100})
+	err := c.Search(context.Background(), AuditLogsSearchInput{Start: "2026-06-30", End: "2026-07-01", Limit: 100})
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
## Summary

- preserve date-only `--end` values as the exclusive boundary sent to the API
- remove the no-longer-needed date-only parsing marker
- clarify the CLI help text and cover the boundary with a regression test

## Testing

- `make test`
- `make build`
- not run: `make lint` (`golangci-lint` is not installed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI time-window semantics for date-only `--end`, which can shrink results for scripts that relied on inclusive end-of-day behavior.
> 
> **Overview**
> **`audit-logs search` now sends `--end` to the API as an exclusive boundary** instead of extending date-only values by 24 hours so the whole calendar day was included.
> 
> `parseAuditLogTime` no longer returns a `dateOnly` flag; date strings like `2026-07-01` are passed through as midnight UTC on that date. The `--end` flag help text now documents exclusivity, and the regression test asserts a window from `2026-06-30` through exclusive `2026-07-01` rather than treating same-day start/end as a full day.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e3be94301f2692322b498f055aae54120c908ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->