### PR TITLE
Bound kernel login token exchange with a timeout

### DIFF
--- a/pkg/auth/oauth.go
+++ b/pkg/auth/oauth.go
@@ -45,6 +45,10 @@ const (
 
 	// OAuth scopes - openid for the MCP server flow
 	DefaultScope = "openid email"
+
+	// tokenExchangeTimeout bounds the token/refresh HTTP calls so a stalled auth
+	// server surfaces as an error instead of hanging the CLI indefinitely.
+	tokenExchangeTimeout = 30 * time.Second
 )
 
 // OAuthConfig represents the OAuth2 configuration
@@ -311,6 +315,9 @@ func (oc *OAuthConfig) exchangeCodeForTokens(ctx context.Context, code, orgID st
 		opts = append(opts, oauth2.SetAuthURLParam("org_id", orgID))
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, tokenExchangeTimeout)
+	defer cancel()
+
 	token, err := oc.Config.Exchange(ctx, code, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to exchange code for token: %w", err)
@@ -349,7 +356,7 @@ func RefreshTokens(ctx context.Context, tokens *TokenStorage) (*TokenStorage, er
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	client := &http.Client{}
+	client := &http.Client{Timeout: tokenExchangeTimeout}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send refresh request: %w", err)


### PR DESCRIPTION
## Summary
`kernel login` used a context with no deadline (`signal.NotifyContext`) and a default HTTP client with no timeout for the OAuth token exchange. When `/token` stalled (e.g. the auth server's Redis was unreachable), the browser showed the success page but the terminal spinner hung until the user hit Ctrl-C.

- Wrap the authorization-code exchange (`exchangeCodeForTokens`) in a 30s context deadline.
- Give the refresh request (`RefreshTokens`) an equivalent `http.Client.Timeout`.

Now a stalled auth server fails with a clear error in seconds instead of hanging the login. Companion to the `kernel-mcp-server` PR that stops the server side from hanging in the first place.

## Test plan
- [x] `go build ./...`, `go vet`, `gofmt`, `go test ./pkg/auth/...` all pass
- [ ] Manual: normal `kernel login` still completes against a healthy auth server (happy path unchanged)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to auth HTTP timeouts; healthy servers behave the same, only failure mode timing changes.
> 
> **Overview**
> **`kernel login`** and token refresh no longer hang indefinitely when the auth server’s `/token` endpoint stalls.
> 
> OAuth code exchange in **`exchangeCodeForTokens`** now runs under a **30s** context deadline. **`RefreshTokens`** uses the same limit via **`http.Client.Timeout`** instead of an unbounded client.
> 
> Stalled auth should surface as a normal error within ~30 seconds instead of leaving the CLI spinner running until Ctrl-C.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efd6c91c10d773f38fe7066c9cc1ea4ca465e28e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->