### PR TITLE
Set default browser pool fill rate

### DIFF
--- a/cmd/browser_pools.go
+++ b/cmd/browser_pools.go
@@ -569,7 +569,7 @@ func init() {
 	browserPoolsCreateCmd.Flags().String("name", "", "Optional unique name for the pool")
 	browserPoolsCreateCmd.Flags().Int64("size", 0, "Number of browsers in the pool")
 	_ = browserPoolsCreateCmd.MarkFlagRequired("size")
-	browserPoolsCreateCmd.Flags().Int64("fill-rate", 0, "Fill rate per minute")
+	browserPoolsCreateCmd.Flags().Int64("fill-rate", 25, "Fill rate per minute")
 	browserPoolsCreateCmd.Flags().Int64("timeout", 0, "Idle timeout in seconds")
 	browserPoolsCreateCmd.Flags().Bool("stealth", false, "Enable stealth mode")
 	browserPoolsCreateCmd.Flags().Bool("headless", false, "Enable headless mode")

--- a/cmd/browser_pools_test.go
+++ b/cmd/browser_pools_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kernel/kernel-go-sdk/option"
 	"github.com/kernel/kernel-go-sdk/packages/pagination"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // FakeBrowserPoolsService is a configurable fake implementing BrowserPoolsService.
@@ -156,6 +157,24 @@ func TestBrowserPoolsCreate_WithRefreshOnProfileUpdate(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, captured.RefreshOnProfileUpdate.Valid())
 	assert.True(t, captured.RefreshOnProfileUpdate.Value)
+}
+
+func TestBrowserPoolsCreate_DefaultFillRate(t *testing.T) {
+	setupStdoutCapture(t)
+
+	var captured kernel.BrowserPoolNewParams
+	fake := &FakeBrowserPoolsService{
+		NewFunc: func(ctx context.Context, body kernel.BrowserPoolNewParams, opts ...option.RequestOption) (*kernel.BrowserPool, error) {
+			captured = body
+			return &kernel.BrowserPool{ID: "pool-default-fill-rate"}, nil
+		},
+	}
+
+	c := BrowserPoolsCmd{client: fake}
+	err := c.Create(context.Background(), BrowserPoolsCreateInput{Size: 1, FillRate: 25})
+	require.NoError(t, err)
+	assert.True(t, captured.FillRatePerMinute.Valid())
+	assert.Equal(t, int64(25), captured.FillRatePerMinute.Value)
 }
 
 func TestBrowserPoolsUpdate_WithRefreshOnProfileUpdate(t *testing.T) {


### PR DESCRIPTION
## Summary
address KERNEL-1593

- default `kernel browser-pools create` to a fill rate of 25% per minute
- add coverage that verifies the default is sent in the create request

## Test plan
- [x] `go test ./cmd`
- [x] `make build` and create a browser pool, then verify the fill rate is 25% per minute