### PR TITLE
Fix OAuth login hangs after browser callback

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -64,7 +64,7 @@ func runLogin(cmd *cobra.Command, args []string) error {
 		// Handle common error cases with helpful messages
 		if ctx.Err() == context.Canceled {
 			pterm.Info.Println("Authentication cancelled by user")
-			return nil
+			return ctx.Err()
 		}
 
 		return fmt.Errorf("authentication failed: %w", err)

--- a/pkg/auth/oauth.go
+++ b/pkg/auth/oauth.go
@@ -22,14 +22,14 @@ import (
 )
 
 //go:embed success.html
-var successHTMLTemplate string
+var authorizationReceivedHTMLTemplate string
 
 //go:embed favicon.svg
 var faviconSVG string
 
 // Inlined as a data URI because the callback server shuts down before the browser could fetch a served icon.
-var successHTML = strings.Replace(
-	successHTMLTemplate,
+var authorizationReceivedHTML = strings.Replace(
+	authorizationReceivedHTMLTemplate,
 	"__KERNEL_FAVICON__",
 	"data:image/svg+xml;base64,"+base64.StdEncoding.EncodeToString([]byte(faviconSVG)),
 	1,
@@ -45,6 +45,8 @@ const (
 
 	// OAuth scopes - openid for the MCP server flow
 	DefaultScope = "openid email"
+
+	defaultTokenExchangeTimeout = 30 * time.Second
 )
 
 // OAuthConfig represents the OAuth2 configuration
@@ -250,7 +252,7 @@ func (oc *OAuthConfig) StartOAuthFlow(ctx context.Context) (*TokenStorage, error
 		// Success page
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(successHTML))
+		w.Write([]byte(authorizationReceivedHTML))
 
 		// Pass both code and org_id to the channel using JSON encoding
 		result := AuthResult{
@@ -298,12 +300,14 @@ func (oc *OAuthConfig) StartOAuthFlow(ctx context.Context) (*TokenStorage, error
 		return nil, ctx.Err()
 	}
 
+	pterm.Info.Println("Browser authorization received; completing authentication...")
+
 	// Exchange authorization code for tokens
-	return oc.exchangeCodeForTokens(ctx, authCode, orgID)
+	return oc.exchangeCodeForTokens(ctx, authCode, orgID, defaultTokenExchangeTimeout)
 }
 
 // exchangeCodeForTokens exchanges the authorization code for access and refresh tokens
-func (oc *OAuthConfig) exchangeCodeForTokens(ctx context.Context, code, orgID string) (*TokenStorage, error) {
+func (oc *OAuthConfig) exchangeCodeForTokens(ctx context.Context, code, orgID string, timeout time.Duration) (*TokenStorage, error) {
 	// Use PKCE verifier in token exchange, and include org_id if available
 	var opts []oauth2.AuthCodeOption
 	opts = append(opts, oauth2.SetAuthURLParam("code_verifier", oc.Verifier))
@@ -311,8 +315,14 @@ func (oc *OAuthConfig) exchangeCodeForTokens(ctx context.Context, code, orgID st
 		opts = append(opts, oauth2.SetAuthURLParam("org_id", orgID))
 	}
 
-	token, err := oc.Config.Exchange(ctx, code, opts...)
+	exchangeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	token, err := oc.Config.Exchange(exchangeCtx, code, opts...)
 	if err != nil {
+		if exchangeCtx.Err() == context.DeadlineExceeded {
+			return nil, fmt.Errorf("token exchange timed out after %s: %w", timeout, context.DeadlineExceeded)
+		}
 		return nil, fmt.Errorf("failed to exchange code for token: %w", err)
 	}
 

--- a/pkg/auth/oauth_test.go
+++ b/pkg/auth/oauth_test.go
@@ -1,6 +1,58 @@
 package auth
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCallbackPageDoesNotClaimAuthenticationComplete(t *testing.T) {
+	t.Parallel()
+
+	if strings.Contains(authorizationReceivedHTML, "authentication successful") {
+		t.Fatal("callback page must not claim authentication succeeded before token exchange completes")
+	}
+	if !strings.Contains(authorizationReceivedHTML, "authorization received") {
+		t.Fatal("callback page should tell the user browser authorization was received")
+	}
+}
+
+func TestTokenExchangeTimesOut(t *testing.T) {
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-release:
+		}
+	}))
+	defer server.Close()
+	defer close(release)
+
+	cfg, err := NewOAuthConfig()
+	if err != nil {
+		t.Fatalf("NewOAuthConfig() error = %v", err)
+	}
+	cfg.Config.Endpoint.TokenURL = server.URL
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := cfg.exchangeCodeForTokens(context.Background(), "code", "org", 25*time.Millisecond)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "token exchange timed out") || !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("exchange error = %v, want token exchange timeout", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("token exchange did not honor its timeout")
+	}
+}
 
 func TestNewOAuthConfigUsesAuthOverrides(t *testing.T) {
 	t.Setenv("KERNEL_AUTH_BASE_URL", "https://auth.dev.onkernel.com/")

--- a/pkg/auth/success.html
+++ b/pkg/auth/success.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>kernel cli - authenticated</title>
+    <title>kernel cli - authorization received</title>
     <link rel="icon" type="image/svg+xml" href="__KERNEL_FAVICON__">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
     <style>
@@ -88,8 +88,8 @@
                     <path d="M285.036 0C289.434 0 293 3.56173 293 7.95537C293 12.3491 289.434 15.9107 285.036 15.9107C280.638 15.9107 277.072 12.349 277.072 7.95537C277.072 3.56178 280.638 8.45042e-05 285.036 0Z" fill="#1c2024"/>
                 </svg>
             </div>
-            <p class="title">authentication successful</p>
-            <p class="subtitle">you can close this window and return to your terminal.</p>
+            <p class="title">authorization received</p>
+            <p class="subtitle">return to your terminal while the cli completes authentication.</p>
             <div class="check-container">
                 <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>


### PR DESCRIPTION
## What

- Change the browser callback page to say authorization was received, since the CLI has not exchanged the code for tokens yet.
- Show terminal progress while the CLI completes the token exchange.
- Bound the token exchange to 30 seconds.
- Return a cancellation error so Ctrl+C exits nonzero.

## Why

The existing five-minute timeout only covered waiting for the browser callback. After receiving the callback, the token exchange reused a signal-only context with no deadline. If the auth server accepted the connection but never completed the response, the CLI could wait forever while the browser incorrectly reported that authentication had succeeded.

## Before and after

Before:

- The browser reported `authentication successful` before the token exchange.
- The terminal continued to show `Waiting for authentication...` during the exchange.
- A stalled exchange had no timeout.
- Ctrl+C printed cancellation but exited successfully.

After:

- The browser reports `authorization received` and directs the user back to the terminal.
- The terminal reports that it is completing authentication.
- A stalled exchange fails after 30 seconds with a timeout error.
- Ctrl+C exits nonzero.

## Verification

- `make test` (includes `go vet ./...` and `go test ./...`)
- Added a regression test using a deliberately stalled token endpoint and verified the exchange respects its deadline.
- Added a callback-page regression test preventing it from claiming authentication completed before token exchange.
- Built the CLI, started login with browser launch disabled, sent SIGINT, and verified exit code 1.

This makes the CLI bounded and accurate when the upstream token exchange stalls; it does not claim to fix the auth service behavior that caused the original staging response to hang.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the OAuth login path and token exchange timing; bounded change with tests, but failures here block CLI authentication.
> 
> **Overview**
> Fixes **indefinite hangs** after the browser OAuth callback by adding a **30s deadline** on token exchange and tightening login messaging so users are not told auth succeeded before tokens exist.
> 
> The **callback HTML** now says **authorization received** (not authentication successful) and tells users to return to the terminal while the CLI finishes. After the callback, the CLI prints that it is **completing authentication** while `exchangeCodeForTokens` runs with `context.WithTimeout`.
> 
> **Ctrl+C during login** now returns `ctx.Err()` instead of exiting successfully. Regression tests cover the callback copy and stalled token endpoint timeout behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87ac27ef4cd4d7e4a68caa62a5f4b09e45914f33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->