### PR TITLE
Add telemetry support to browser-pools CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,11 +266,12 @@ Commands with JSON output support:
   - `--refresh-on-profile-update` - Flush idle browsers when the pool's profile is updated (requires a profile)
   - `--profile-id`, `--profile-name`, `--proxy-id`, `--start-url`, `--extension`, `--viewport` - Same semantics as `kernel browsers create`
   - `--chrome-policy <json>` / `--chrome-policy-file <path>` - Custom Chrome enterprise policy applied to every browser in the pool, as a JSON object or from a file (`-` for stdin). Same semantics as `kernel browsers create`.
+  - `--telemetry=all` / `--telemetry=off` / `--telemetry=<categories>` - Telemetry applied to browsers warmed into the pool. Same semantics as `kernel browsers create`.
   - `--output json`, `-o json` - Output raw JSON object
 - `kernel browser-pools get <id-or-name>` - Get pool details
   - `--output json`, `-o json` - Output raw JSON object
 - `kernel browser-pools update <id-or-name>` - Update pool configuration
-  - Same flags as create plus `--clear-start-url` (remove the pool's start URL) and `--discard-all-idle` (discard all idle browsers and refill). An empty `--chrome-policy '{}'` is ignored and does not clear an existing policy; recreate the pool to remove one.
+  - Same flags as create plus `--clear-start-url` (remove the pool's start URL) and `--discard-all-idle` (discard all idle browsers and refill). An empty `--chrome-policy '{}'` is ignored and does not clear an existing policy; recreate the pool to remove one. `--telemetry` updates only apply to browsers warmed after the update.
   - `--output json`, `-o json` - Output raw JSON object
 - `kernel browser-pools delete <id-or-name>` - Delete a pool
   - `--force` - Force delete even if browsers are leased
@@ -278,6 +279,7 @@ Commands with JSON output support:
   - `--timeout <seconds>` - Acquire timeout before returning 204
   - `--name <name>` - Optional name for the acquired session (applies to this lease; cleared on release)
   - `--tag <KEY=VALUE>` - Set a tag on the acquired session, repeatable; applies to this lease
+  - `--telemetry=all` / `--telemetry=off` / `--telemetry=<categories>` - Telemetry override for this lease only, merged onto the pool's config
   - `--output json`, `-o json` - Output raw JSON object
 - `kernel browser-pools release <id-or-name>` - Release a browser back to the pool
   - `--session-id <id>` - Browser session ID to release (required)

--- a/cmd/browser_pools.go
+++ b/cmd/browser_pools.go
@@ -90,6 +90,63 @@ func (c BrowserPoolsCmd) List(ctx context.Context, in BrowserPoolsListInput) err
 	return nil
 }
 
+// buildPoolNewTelemetryParam converts a --telemetry flag value to the pool create param.
+func buildPoolNewTelemetryParam(s string) (kernel.BrowserPoolNewParamsTelemetry, error) {
+	switch s {
+	case "all":
+		return kernel.BrowserPoolNewParamsTelemetry{Enabled: kernel.Opt(true)}, nil
+	case "off":
+		return kernel.BrowserPoolNewParamsTelemetry{Enabled: kernel.Opt(false)}, nil
+	default:
+		p, err := parseTelemetryCategories(s)
+		if err != nil {
+			return kernel.BrowserPoolNewParamsTelemetry{}, err
+		}
+		return kernel.BrowserPoolNewParamsTelemetry{Browser: p}, nil
+	}
+}
+
+// buildPoolUpdateTelemetryParam converts a --telemetry flag value to the pool update param.
+func buildPoolUpdateTelemetryParam(s string) (kernel.BrowserPoolUpdateParamsTelemetry, error) {
+	switch s {
+	case "all":
+		return kernel.BrowserPoolUpdateParamsTelemetry{Enabled: kernel.Opt(true)}, nil
+	case "off":
+		return kernel.BrowserPoolUpdateParamsTelemetry{Enabled: kernel.Opt(false)}, nil
+	default:
+		p, err := parseTelemetryCategories(s)
+		if err != nil {
+			return kernel.BrowserPoolUpdateParamsTelemetry{}, err
+		}
+		return kernel.BrowserPoolUpdateParamsTelemetry{Browser: p}, nil
+	}
+}
+
+// buildPoolAcquireTelemetryParam converts a --telemetry flag value to the acquire override param.
+func buildPoolAcquireTelemetryParam(s string) (kernel.BrowserPoolAcquireParamsTelemetry, error) {
+	switch s {
+	case "all":
+		return kernel.BrowserPoolAcquireParamsTelemetry{Enabled: kernel.Opt(true)}, nil
+	case "off":
+		return kernel.BrowserPoolAcquireParamsTelemetry{Enabled: kernel.Opt(false)}, nil
+	default:
+		p, err := parseTelemetryCategories(s)
+		if err != nil {
+			return kernel.BrowserPoolAcquireParamsTelemetry{}, err
+		}
+		return kernel.BrowserPoolAcquireParamsTelemetry{Browser: p}, nil
+	}
+}
+
+// formatPoolTelemetry renders a pool's active telemetry config for the details table.
+func formatPoolTelemetry(cfg kernel.BrowserTelemetryConfig) string {
+	on := telemetryEnabledCategories(cfg)
+	if len(on) == 0 {
+		return "disabled"
+	}
+	return strings.Join(on, ", ")
+}
+
 type BrowserPoolsCreateInput struct {
 	Name                   string
 	Size                   int64
@@ -107,6 +164,7 @@ type BrowserPoolsCreateInput struct {
 	Viewport         string
 	ChromePolicy     string
 	ChromePolicyFile string
+	Telemetry        string
 	Output           string
 }
 
@@ -183,6 +241,14 @@ func (c BrowserPoolsCmd) Create(ctx context.Context, in BrowserPoolsCreateInput)
 		params.ChromePolicy = chromePolicy
 	}
 
+	if in.Telemetry != "" {
+		t, err := buildPoolNewTelemetryParam(in.Telemetry)
+		if err != nil {
+			return err
+		}
+		params.Telemetry = t
+	}
+
 	pool, err := c.client.New(ctx, params)
 	if err != nil {
 		return util.CleanedUpSdkError{Err: err}
@@ -196,6 +262,9 @@ func (c BrowserPoolsCmd) Create(ctx context.Context, in BrowserPoolsCreateInput)
 		pterm.Success.Printf("Created browser pool %s (%s)\n", pool.Name, pool.ID)
 	} else {
 		pterm.Success.Printf("Created browser pool %s\n", pool.ID)
+	}
+	if in.Telemetry != "" {
+		printTelemetrySummary(pool.BrowserPoolConfig.Telemetry)
 	}
 	return nil
 }
@@ -240,6 +309,7 @@ func (c BrowserPoolsCmd) Get(ctx context.Context, in BrowserPoolsGetInput) error
 		{"Start URL", util.OrDash(cfg.StartURL)},
 		{"Extensions", formatExtensions(cfg.Extensions)},
 		{"Viewport", formatViewport(cfg.Viewport)},
+		{"Telemetry", formatPoolTelemetry(cfg.Telemetry)},
 	}
 
 	PrintTableNoPad(rows, true)
@@ -265,6 +335,7 @@ type BrowserPoolsUpdateInput struct {
 	Viewport         string
 	ChromePolicy     string
 	ChromePolicyFile string
+	Telemetry        string
 	DiscardAllIdle   BoolFlag
 	Output           string
 }
@@ -356,6 +427,14 @@ func (c BrowserPoolsCmd) Update(ctx context.Context, in BrowserPoolsUpdateInput)
 		pterm.Warning.Println("An empty chrome policy is ignored and does not clear the pool's existing policy; recreate the pool to remove a policy.")
 	}
 
+	if in.Telemetry != "" {
+		t, err := buildPoolUpdateTelemetryParam(in.Telemetry)
+		if err != nil {
+			return err
+		}
+		params.Telemetry = t
+	}
+
 	pool, err := c.client.Update(ctx, in.IDOrName, params)
 	if err != nil {
 		return util.CleanedUpSdkError{Err: err}
@@ -369,6 +448,9 @@ func (c BrowserPoolsCmd) Update(ctx context.Context, in BrowserPoolsUpdateInput)
 		pterm.Success.Printf("Updated browser pool %s (%s)\n", pool.Name, pool.ID)
 	} else {
 		pterm.Success.Printf("Updated browser pool %s\n", pool.ID)
+	}
+	if in.Telemetry != "" {
+		printTelemetrySummary(pool.BrowserPoolConfig.Telemetry)
 	}
 	return nil
 }
@@ -396,13 +478,15 @@ type BrowserPoolsAcquireInput struct {
 	TimeoutSeconds int64
 	Name           string
 	Tags           map[string]string
+	Telemetry      string
 	Output         string
 }
 
 // buildAcquireParams builds the SDK params for acquiring a browser from a pool.
 // Shared by `browser-pools acquire` and the `browsers create --pool-id/--pool-name`
-// path so the per-lease name/tags forwarding cannot silently diverge between them.
-func buildAcquireParams(name string, tags map[string]string, timeoutSeconds int64) kernel.BrowserPoolAcquireParams {
+// path so the per-lease name/tags/telemetry forwarding cannot silently diverge
+// between them. The telemetry override merges onto the pool's config for this lease.
+func buildAcquireParams(name string, tags map[string]string, timeoutSeconds int64, telemetry string) (kernel.BrowserPoolAcquireParams, error) {
 	params := kernel.BrowserPoolAcquireParams{}
 	if timeoutSeconds > 0 {
 		params.AcquireTimeoutSeconds = kernel.Int(timeoutSeconds)
@@ -413,7 +497,14 @@ func buildAcquireParams(name string, tags map[string]string, timeoutSeconds int6
 	if len(tags) > 0 {
 		params.Tags = kernel.Tags(tags)
 	}
-	return params
+	if telemetry != "" {
+		t, err := buildPoolAcquireTelemetryParam(telemetry)
+		if err != nil {
+			return kernel.BrowserPoolAcquireParams{}, err
+		}
+		params.Telemetry = t
+	}
+	return params, nil
 }
 
 func (c BrowserPoolsCmd) Acquire(ctx context.Context, in BrowserPoolsAcquireInput) error {
@@ -421,7 +512,10 @@ func (c BrowserPoolsCmd) Acquire(ctx context.Context, in BrowserPoolsAcquireInpu
 		return err
 	}
 
-	params := buildAcquireParams(in.Name, in.Tags, in.TimeoutSeconds)
+	params, err := buildAcquireParams(in.Name, in.Tags, in.TimeoutSeconds, in.Telemetry)
+	if err != nil {
+		return err
+	}
 	resp, err := c.client.Acquire(ctx, in.IDOrName, params)
 	if err != nil {
 		return util.CleanedUpSdkError{Err: err}
@@ -583,6 +677,7 @@ func init() {
 	browserPoolsCreateCmd.Flags().String("viewport", "", "Viewport size (e.g. 1280x800)")
 	browserPoolsCreateCmd.Flags().String("chrome-policy", "", "Custom Chrome enterprise policy as a JSON object")
 	browserPoolsCreateCmd.Flags().String("chrome-policy-file", "", "Read Chrome enterprise policy (JSON object) from a file (use '-' for stdin)")
+	browserPoolsCreateCmd.Flags().String("telemetry", "", "Configure telemetry for browsers warmed into the pool (opt-in): --telemetry=all (default set), --telemetry=off (disable), or --telemetry=console,network (capture exactly those categories)")
 	browserPoolsCreateCmd.MarkFlagsMutuallyExclusive("chrome-policy", "chrome-policy-file")
 
 	addJSONOutputFlag(browserPoolsGetCmd)
@@ -605,6 +700,7 @@ func init() {
 	browserPoolsUpdateCmd.Flags().String("chrome-policy", "", "Custom Chrome enterprise policy as a JSON object")
 	browserPoolsUpdateCmd.Flags().String("chrome-policy-file", "", "Read Chrome enterprise policy (JSON object) from a file (use '-' for stdin)")
 	browserPoolsUpdateCmd.MarkFlagsMutuallyExclusive("chrome-policy", "chrome-policy-file")
+	browserPoolsUpdateCmd.Flags().String("telemetry", "", "Update pool telemetry: --telemetry=all (reset to default set), --telemetry=off (disable), or --telemetry=console,network (merge those categories into the current selection). Applies only to browsers warmed after the update.")
 	browserPoolsUpdateCmd.Flags().Bool("discard-all-idle", false, "Discard all idle browsers")
 	addJSONOutputFlag(browserPoolsUpdateCmd)
 
@@ -613,6 +709,7 @@ func init() {
 	browserPoolsAcquireCmd.Flags().Int64("timeout", 0, "Acquire timeout in seconds")
 	browserPoolsAcquireCmd.Flags().String("name", "", "Optional name for the acquired session (applies to this lease; cleared on release)")
 	browserPoolsAcquireCmd.Flags().StringArray("tag", nil, "Set a tag KEY=VALUE on the acquired session (repeatable; applies to this lease)")
+	browserPoolsAcquireCmd.Flags().String("telemetry", "", "Telemetry override for this lease only, merged onto the pool's config: --telemetry=all, --telemetry=off, or --telemetry=console,network")
 	addJSONOutputFlag(browserPoolsAcquireCmd)
 
 	browserPoolsReleaseCmd.Flags().String("session-id", "", "Browser session ID to release")
@@ -663,6 +760,7 @@ func runBrowserPoolsCreate(cmd *cobra.Command, args []string) error {
 	viewport, _ := cmd.Flags().GetString("viewport")
 	chromePolicy, _ := cmd.Flags().GetString("chrome-policy")
 	chromePolicyFile, _ := cmd.Flags().GetString("chrome-policy-file")
+	telemetry, _ := cmd.Flags().GetString("telemetry")
 	output, _ := cmd.Flags().GetString("output")
 
 	in := BrowserPoolsCreateInput{
@@ -682,6 +780,7 @@ func runBrowserPoolsCreate(cmd *cobra.Command, args []string) error {
 		Viewport:         viewport,
 		ChromePolicy:     chromePolicy,
 		ChromePolicyFile: chromePolicyFile,
+		Telemetry:        telemetry,
 		Output:           output,
 	}
 
@@ -716,6 +815,7 @@ func runBrowserPoolsUpdate(cmd *cobra.Command, args []string) error {
 	viewport, _ := cmd.Flags().GetString("viewport")
 	chromePolicy, _ := cmd.Flags().GetString("chrome-policy")
 	chromePolicyFile, _ := cmd.Flags().GetString("chrome-policy-file")
+	telemetry, _ := cmd.Flags().GetString("telemetry")
 	discardIdle, _ := cmd.Flags().GetBool("discard-all-idle")
 	output, _ := cmd.Flags().GetString("output")
 
@@ -738,6 +838,7 @@ func runBrowserPoolsUpdate(cmd *cobra.Command, args []string) error {
 		Viewport:         viewport,
 		ChromePolicy:     chromePolicy,
 		ChromePolicyFile: chromePolicyFile,
+		Telemetry:        telemetry,
 		DiscardAllIdle:   BoolFlag{Set: cmd.Flags().Changed("discard-all-idle"), Value: discardIdle},
 		Output:           output,
 	}
@@ -758,6 +859,7 @@ func runBrowserPoolsAcquire(cmd *cobra.Command, args []string) error {
 	timeout, _ := cmd.Flags().GetInt64("timeout")
 	name, _ := cmd.Flags().GetString("name")
 	tags, _ := tagsFromFlag(cmd, "tag")
+	telemetry, _ := cmd.Flags().GetString("telemetry")
 	output, _ := cmd.Flags().GetString("output")
 	c := BrowserPoolsCmd{client: &client.BrowserPools}
 	return c.Acquire(cmd.Context(), BrowserPoolsAcquireInput{
@@ -765,6 +867,7 @@ func runBrowserPoolsAcquire(cmd *cobra.Command, args []string) error {
 		TimeoutSeconds: timeout,
 		Name:           name,
 		Tags:           tags,
+		Telemetry:      telemetry,
 		Output:         output,
 	})
 }

--- a/cmd/browser_pools.go
+++ b/cmd/browser_pools.go
@@ -92,50 +92,20 @@ func (c BrowserPoolsCmd) List(ctx context.Context, in BrowserPoolsListInput) err
 
 // buildPoolNewTelemetryParam converts a --telemetry flag value to the pool create param.
 func buildPoolNewTelemetryParam(s string) (kernel.BrowserPoolNewParamsTelemetry, error) {
-	switch s {
-	case "all":
-		return kernel.BrowserPoolNewParamsTelemetry{Enabled: kernel.Opt(true)}, nil
-	case "off":
-		return kernel.BrowserPoolNewParamsTelemetry{Enabled: kernel.Opt(false)}, nil
-	default:
-		p, err := parseTelemetryCategories(s)
-		if err != nil {
-			return kernel.BrowserPoolNewParamsTelemetry{}, err
-		}
-		return kernel.BrowserPoolNewParamsTelemetry{Browser: p}, nil
-	}
+	enabled, browser, err := resolveTelemetryFlag(s)
+	return kernel.BrowserPoolNewParamsTelemetry{Enabled: enabled, Browser: browser}, err
 }
 
 // buildPoolUpdateTelemetryParam converts a --telemetry flag value to the pool update param.
 func buildPoolUpdateTelemetryParam(s string) (kernel.BrowserPoolUpdateParamsTelemetry, error) {
-	switch s {
-	case "all":
-		return kernel.BrowserPoolUpdateParamsTelemetry{Enabled: kernel.Opt(true)}, nil
-	case "off":
-		return kernel.BrowserPoolUpdateParamsTelemetry{Enabled: kernel.Opt(false)}, nil
-	default:
-		p, err := parseTelemetryCategories(s)
-		if err != nil {
-			return kernel.BrowserPoolUpdateParamsTelemetry{}, err
-		}
-		return kernel.BrowserPoolUpdateParamsTelemetry{Browser: p}, nil
-	}
+	enabled, browser, err := resolveTelemetryFlag(s)
+	return kernel.BrowserPoolUpdateParamsTelemetry{Enabled: enabled, Browser: browser}, err
 }
 
 // buildPoolAcquireTelemetryParam converts a --telemetry flag value to the acquire override param.
 func buildPoolAcquireTelemetryParam(s string) (kernel.BrowserPoolAcquireParamsTelemetry, error) {
-	switch s {
-	case "all":
-		return kernel.BrowserPoolAcquireParamsTelemetry{Enabled: kernel.Opt(true)}, nil
-	case "off":
-		return kernel.BrowserPoolAcquireParamsTelemetry{Enabled: kernel.Opt(false)}, nil
-	default:
-		p, err := parseTelemetryCategories(s)
-		if err != nil {
-			return kernel.BrowserPoolAcquireParamsTelemetry{}, err
-		}
-		return kernel.BrowserPoolAcquireParamsTelemetry{Browser: p}, nil
-	}
+	enabled, browser, err := resolveTelemetryFlag(s)
+	return kernel.BrowserPoolAcquireParamsTelemetry{Enabled: enabled, Browser: browser}, err
 }
 
 // formatPoolTelemetry renders a pool's active telemetry config for the details table.

--- a/cmd/browser_pools_test.go
+++ b/cmd/browser_pools_test.go
@@ -120,21 +120,29 @@ func TestBrowserPoolsList_ForwardsLimitOffset(t *testing.T) {
 	assert.Equal(t, int64(8), captured.Offset.Value)
 }
 
-// TestBuildAcquireParams covers the shared name/tags/timeout forwarding used by
-// both `browser-pools acquire` and the `browsers create --pool-id` lease path.
+// TestBuildAcquireParams covers the shared name/tags/timeout/telemetry forwarding
+// used by both `browser-pools acquire` and the `browsers create --pool-id` lease path.
 func TestBuildAcquireParams(t *testing.T) {
-	p := buildAcquireParams("lease", map[string]string{"env": "prod"}, 30)
+	p, err := buildAcquireParams("lease", map[string]string{"env": "prod"}, 30, "console,network")
+	assert.NoError(t, err)
 	assert.True(t, p.Name.Valid())
 	assert.Equal(t, "lease", p.Name.Value)
 	assert.Equal(t, "prod", p.Tags["env"])
 	assert.True(t, p.AcquireTimeoutSeconds.Valid())
 	assert.Equal(t, int64(30), p.AcquireTimeoutSeconds.Value)
+	assert.True(t, p.Telemetry.Browser.Console.Enabled.Value)
+	assert.True(t, p.Telemetry.Browser.Network.Enabled.Value)
 
 	// Unset inputs produce an empty params struct (nothing forwarded).
-	empty := buildAcquireParams("", nil, 0)
+	empty, err := buildAcquireParams("", nil, 0, "")
+	assert.NoError(t, err)
 	assert.False(t, empty.Name.Valid())
 	assert.Len(t, empty.Tags, 0)
 	assert.False(t, empty.AcquireTimeoutSeconds.Valid())
+
+	// An invalid category surfaces an error rather than a partial param.
+	_, err = buildAcquireParams("", nil, 0, "bogus")
+	assert.Error(t, err)
 }
 
 func TestBrowserPoolsCreate_WithRefreshOnProfileUpdate(t *testing.T) {
@@ -275,4 +283,101 @@ func TestBrowserPoolsUpdate_EmptyChromePolicyQuietInJSONMode(t *testing.T) {
 	assert.NoError(t, err)
 	// The warning must not leak onto stdout in json mode, where it would corrupt the payload.
 	assert.NotContains(t, outBuf.String(), "does not clear")
+}
+
+func TestBrowserPoolsCreate_WithTelemetry(t *testing.T) {
+	setupStdoutCapture(t)
+
+	var captured kernel.BrowserPoolNewParams
+	fake := &FakeBrowserPoolsService{
+		NewFunc: func(ctx context.Context, body kernel.BrowserPoolNewParams, opts ...option.RequestOption) (*kernel.BrowserPool, error) {
+			captured = body
+			return &kernel.BrowserPool{ID: "pool-tel"}, nil
+		},
+	}
+
+	c := BrowserPoolsCmd{client: fake}
+	err := c.Create(context.Background(), BrowserPoolsCreateInput{
+		Size:      1,
+		Telemetry: "console,network",
+	})
+	assert.NoError(t, err)
+	assert.True(t, captured.Telemetry.Browser.Console.Enabled.Value)
+	assert.True(t, captured.Telemetry.Browser.Network.Enabled.Value)
+	assert.False(t, captured.Telemetry.Enabled.Valid())
+}
+
+func TestBrowserPoolsCreate_TelemetryAllAndOff(t *testing.T) {
+	setupStdoutCapture(t)
+
+	var captured kernel.BrowserPoolNewParams
+	fake := &FakeBrowserPoolsService{
+		NewFunc: func(ctx context.Context, body kernel.BrowserPoolNewParams, opts ...option.RequestOption) (*kernel.BrowserPool, error) {
+			captured = body
+			return &kernel.BrowserPool{ID: "pool-tel"}, nil
+		},
+	}
+	c := BrowserPoolsCmd{client: fake}
+
+	assert.NoError(t, c.Create(context.Background(), BrowserPoolsCreateInput{Size: 1, Telemetry: "all"}))
+	assert.True(t, captured.Telemetry.Enabled.Value)
+
+	assert.NoError(t, c.Create(context.Background(), BrowserPoolsCreateInput{Size: 1, Telemetry: "off"}))
+	assert.True(t, captured.Telemetry.Enabled.Valid())
+	assert.False(t, captured.Telemetry.Enabled.Value)
+}
+
+func TestBrowserPoolsCreate_TelemetryInvalidCategory(t *testing.T) {
+	setupStdoutCapture(t)
+
+	fake := &FakeBrowserPoolsService{
+		NewFunc: func(ctx context.Context, body kernel.BrowserPoolNewParams, opts ...option.RequestOption) (*kernel.BrowserPool, error) {
+			t.Fatal("New should not be called when telemetry parsing fails")
+			return nil, nil
+		},
+	}
+	c := BrowserPoolsCmd{client: fake}
+	err := c.Create(context.Background(), BrowserPoolsCreateInput{Size: 1, Telemetry: "bogus"})
+	assert.Error(t, err)
+}
+
+func TestBrowserPoolsUpdate_WithTelemetry(t *testing.T) {
+	setupStdoutCapture(t)
+
+	var captured kernel.BrowserPoolUpdateParams
+	fake := &FakeBrowserPoolsService{
+		UpdateFunc: func(ctx context.Context, id string, body kernel.BrowserPoolUpdateParams, opts ...option.RequestOption) (*kernel.BrowserPool, error) {
+			captured = body
+			return &kernel.BrowserPool{ID: id}, nil
+		},
+	}
+
+	c := BrowserPoolsCmd{client: fake}
+	err := c.Update(context.Background(), BrowserPoolsUpdateInput{
+		IDOrName:  "pool-1",
+		Telemetry: "off",
+	})
+	assert.NoError(t, err)
+	assert.True(t, captured.Telemetry.Enabled.Valid())
+	assert.False(t, captured.Telemetry.Enabled.Value)
+}
+
+func TestBrowserPoolsAcquire_WithTelemetryOverride(t *testing.T) {
+	setupStdoutCapture(t)
+
+	var captured kernel.BrowserPoolAcquireParams
+	fake := &FakeBrowserPoolsService{
+		AcquireFunc: func(ctx context.Context, id string, body kernel.BrowserPoolAcquireParams, opts ...option.RequestOption) (*kernel.BrowserPoolAcquireResponse, error) {
+			captured = body
+			return &kernel.BrowserPoolAcquireResponse{SessionID: "sess-1"}, nil
+		},
+	}
+
+	c := BrowserPoolsCmd{client: fake}
+	err := c.Acquire(context.Background(), BrowserPoolsAcquireInput{
+		IDOrName:  "pool-1",
+		Telemetry: "page",
+	})
+	assert.NoError(t, err)
+	assert.True(t, captured.Telemetry.Browser.Page.Enabled.Value)
 }

--- a/cmd/browsers.go
+++ b/cmd/browsers.go
@@ -2801,6 +2801,7 @@ func poolLeaseAllowedFlags() map[string]bool {
 		"timeout":   true,
 		"name":      true,
 		"tag":       true,
+		"telemetry": true,
 		"output":    true,
 		// Global persistent flags that don't configure browsers
 		"no-color":  true,
@@ -2842,7 +2843,7 @@ func runBrowsersCreate(cmd *cobra.Command, args []string) error {
 
 	if poolID != "" || poolName != "" {
 		// When using a pool, configuration comes from the pool itself, but
-		// name and tags apply per-lease to the acquired session.
+		// name, tags, and telemetry apply per-lease to the acquired session.
 		allowedFlags := poolLeaseAllowedFlags()
 
 		// Check if any browser configuration flags were set (which would conflict).
@@ -2884,7 +2885,10 @@ func runBrowsersCreate(cmd *cobra.Command, args []string) error {
 		if cmd.Flags().Changed("timeout") && timeout > 0 {
 			acquireTimeout = int64(timeout)
 		}
-		acquireParams := buildAcquireParams(name, tags, acquireTimeout)
+		acquireParams, err := buildAcquireParams(name, tags, acquireTimeout, telemetry)
+		if err != nil {
+			return err
+		}
 
 		resp, err := (&poolSvc).Acquire(cmd.Context(), pool, acquireParams)
 		if err != nil {

--- a/cmd/browsers_telemetry.go
+++ b/cmd/browsers_telemetry.go
@@ -18,6 +18,7 @@ import (
 	kernel "github.com/kernel/kernel-go-sdk"
 	"github.com/kernel/kernel-go-sdk/option"
 	"github.com/kernel/kernel-go-sdk/packages/pagination"
+	"github.com/kernel/kernel-go-sdk/packages/param"
 	"github.com/kernel/kernel-go-sdk/packages/ssestream"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
@@ -90,36 +91,32 @@ func parseTelemetryCategories(s string) (kernel.BrowserTelemetryCategoriesConfig
 	return p, nil
 }
 
-// buildNewTelemetryParam converts a --telemetry flag value to the create API param.
-func buildNewTelemetryParam(s string) (kernel.BrowserNewParamsTelemetry, error) {
+// resolveTelemetryFlag interprets a --telemetry flag value shared by every browser
+// and browser-pool command: "all" enables the default set, "off" disables capture,
+// and a comma-separated list opts into exactly those categories. It returns the
+// resolved (enabled, browser) pair so each endpoint can assemble its own param type.
+func resolveTelemetryFlag(s string) (param.Opt[bool], kernel.BrowserTelemetryCategoriesConfigParam, error) {
 	switch s {
 	case "all":
-		return kernel.BrowserNewParamsTelemetry{Enabled: kernel.Opt(true)}, nil
+		return kernel.Opt(true), kernel.BrowserTelemetryCategoriesConfigParam{}, nil
 	case "off":
-		return kernel.BrowserNewParamsTelemetry{Enabled: kernel.Opt(false)}, nil
+		return kernel.Opt(false), kernel.BrowserTelemetryCategoriesConfigParam{}, nil
 	default:
 		p, err := parseTelemetryCategories(s)
-		if err != nil {
-			return kernel.BrowserNewParamsTelemetry{}, err
-		}
-		return kernel.BrowserNewParamsTelemetry{Browser: p}, nil
+		return param.Opt[bool]{}, p, err
 	}
+}
+
+// buildNewTelemetryParam converts a --telemetry flag value to the create API param.
+func buildNewTelemetryParam(s string) (kernel.BrowserNewParamsTelemetry, error) {
+	enabled, browser, err := resolveTelemetryFlag(s)
+	return kernel.BrowserNewParamsTelemetry{Enabled: enabled, Browser: browser}, err
 }
 
 // buildUpdateTelemetryParam converts a --telemetry flag value to the update API param.
 func buildUpdateTelemetryParam(s string) (kernel.BrowserUpdateParamsTelemetry, error) {
-	switch s {
-	case "all":
-		return kernel.BrowserUpdateParamsTelemetry{Enabled: kernel.Opt(true)}, nil
-	case "off":
-		return kernel.BrowserUpdateParamsTelemetry{Enabled: kernel.Opt(false)}, nil
-	default:
-		p, err := parseTelemetryCategories(s)
-		if err != nil {
-			return kernel.BrowserUpdateParamsTelemetry{}, err
-		}
-		return kernel.BrowserUpdateParamsTelemetry{Browser: p}, nil
-	}
+	enabled, browser, err := resolveTelemetryFlag(s)
+	return kernel.BrowserUpdateParamsTelemetry{Enabled: enabled, Browser: browser}, err
 }
 
 // settableCategories are the categories accepted by --telemetry=<categories>.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.1
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/joho/godotenv v1.5.1
-	github.com/kernel/kernel-go-sdk v0.78.0
+	github.com/kernel/kernel-go-sdk v0.79.0
 	github.com/klauspost/compress v1.18.5
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pterm/pterm v0.12.80

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
-github.com/kernel/kernel-go-sdk v0.78.0 h1:ZUmQ7Pg9A0dz8SVosFScYPETg/E4e6y7JtNB30OLPZE=
-github.com/kernel/kernel-go-sdk v0.78.0/go.mod h1:EeZzSuHZVeHKxKCPUzxou2bovNGhXaz0RXrSqKNf1AQ=
+github.com/kernel/kernel-go-sdk v0.79.0 h1:1vBV1MWL508p2EGs+PXSztiJOnAQW2cqCDOcSB1ZypQ=
+github.com/kernel/kernel-go-sdk v0.79.0/go.mod h1:EeZzSuHZVeHKxKCPUzxou2bovNGhXaz0RXrSqKNf1AQ=
 github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
 github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=


### PR DESCRIPTION
Brings the CLI to parity with the API/SDK browser-pool telemetry surface (shipped in kernel-go-sdk v0.79.0).

## What changed

- `kernel browser-pools create --telemetry=all|off|<categories>` sets the telemetry applied to browsers warmed into the pool.
- `kernel browser-pools update --telemetry=...` updates pool telemetry. Only applies to browsers warmed after the update.
- `kernel browser-pools acquire --telemetry=...` sets a per-lease override, merged onto the pool config.
- `kernel browser-pools get` now shows the pool's active telemetry in the details table.
- `kernel browsers create --pool-id/--pool-name --telemetry=...` now accepts `--telemetry` as a per-lease flag and forwards it as an acquire override. Previously it was treated as a conflicting config flag and dropped.
- Bumps kernel-go-sdk to v0.79.0.

Pool and browser `--telemetry` share the same parsing (`all` / `off` / comma-separated categories), so they behave identically.

## Testing

Built `bin/kernel` off this branch and exercised each new path end-to-end:

| Scenario | Result |
|----------|--------|
| `browser-pools create --telemetry=console,network` | stored config = console, network + operational set |
| `browser-pools get` | new Telemetry row renders the active categories |
| `browser-pools update --telemetry=all` / `=off` | resets to default set / disables; confirmed via `get` |
| `browser-pools acquire --telemetry=page` | override reaches the leased browser |
| `browsers create --pool-name … --telemetry=console` | forwarded as an acquire override (previously dropped) |
| invalid `--telemetry` on create/update/acquire | rejected before the API call, nothing created or leased |

---
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only feature parity with the SDK; validation runs before API calls and behavior mirrors existing browser telemetry flags.
> 
> **Overview**
> Adds **`--telemetry`** to browser pool **create**, **update**, and **acquire**, aligned with single-browser telemetry (`all` / `off` / category lists) via a shared **`resolveTelemetryFlag`** helper and SDK **v0.79.0**.
> 
> Pool **create**/**update** send telemetry on warmed browsers; **update** only affects browsers warmed after the change. **Acquire** (and **`browsers create --pool-id|--pool-name`**) can pass a per-lease override merged onto the pool config—**`--telemetry`** is now allowed on the pool lease path instead of being treated as a conflicting flag. **`browser-pools get`** shows a **Telemetry** row; create/update print **`printTelemetrySummary`** when the flag is set.
> 
> README documents the new flags. Tests cover pool telemetry params, acquire forwarding, and invalid categories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e54cb3bf50069200f9e8478fc6d57baeff979da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
