### PR TITLE
Uppercase only the first rune of CLI error messages

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/charmbracelet/fang"
 	"github.com/charmbracelet/lipgloss/v2"
@@ -229,7 +231,12 @@ func Execute(m Metadata) {
 
 			// remove margins so that it matches other pterm.error "style"
 			// we should add them back later as it looks cleaner
-			errorTextStyle := styles.ErrorText.UnsetMargins()
+			//
+			// fang's default transform title-cases the first word, which
+			// mangles messages that start with a path or identifier
+			// ("/tmp/out.gz" becomes "/Tmp/Out.gz"); uppercase only the
+			// first rune instead.
+			errorTextStyle := styles.ErrorText.UnsetMargins().Transform(upperFirst)
 
 			// Keep command errors on fang's error stream, normally stderr. This
 			// gives curl-like commands a quiet stdout for response bodies and
@@ -259,6 +266,15 @@ func Execute(m Metadata) {
 // isUsageError is a hack to detect usage errors.
 // See: https://github.com/spf13/cobra/pull/2266
 // from github.com/charmbracelet/fang/help.go
+// upperFirst uppercases the first rune of s, leaving the rest untouched.
+func upperFirst(s string) string {
+	r, size := utf8.DecodeRuneInString(s)
+	if r == utf8.RuneError {
+		return s
+	}
+	return string(unicode.ToUpper(r)) + s[size:]
+}
+
 func isUsageError(err error) bool {
 	s := err.Error()
 	for _, prefix := range []string{

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -94,3 +94,18 @@ func TestResolveProjectSelection(t *testing.T) {
 		assert.Equal(t, "", resolveProjectSelection(""))
 	})
 }
+
+func TestUpperFirst(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"unknown flag: --foo", "Unknown flag: --foo"},
+		{"/tmp/out.jsonl.gz already exists", "/tmp/out.jsonl.gz already exists"},
+		{"--start must be before --end", "--start must be before --end"},
+		{"", ""},
+	}
+	for _, test := range tests {
+		assert.Equal(t, test.want, upperFirst(test.in))
+	}
+}


### PR DESCRIPTION
## Summary

fang's default `ErrorText` style applies a `titleFirstWord` transform that runs `cases.Title` over the first whitespace-delimited word of an error message. `cases.Title` capitalizes after every unicode word boundary inside the token (`/` and `-` included), so any error that begins with a path or identifier gets mangled:

```
ERROR  /Tmp/Audit-Smoke.jsonl.gz already exists; pass --force to overwrite
```

This replaces the transform in our error handler with one that uppercases only the first rune of the message:

- `unknown flag: --foo` → `Unknown flag: --foo` (sentence casing preserved)
- `/tmp/out.jsonl.gz already exists` → unchanged
- `--start must be before --end` → unchanged

## Test plan

- [x] `go test ./cmd` (includes new `TestUpperFirst` unit test)
- [x] `go vet ./...`
- [x] Manual check: `kernel browsers --bogus-flag` renders `Unknown flag: --bogus-flag`