### PR TITLE
Show user IDs separately in audit log search results

### DIFF
--- a/cmd/audit_logs.go
+++ b/cmd/audit_logs.go
@@ -112,7 +112,7 @@ func (c AuditLogsCmd) Search(ctx context.Context, in AuditLogsSearchInput) error
 		return nil
 	}
 
-	table := pterm.TableData{{"Timestamp", "Method", "Status", "Path", "User", "Duration (ms)", "Client IP"}}
+	table := pterm.TableData{{"Timestamp", "Method", "Status", "Path", "User", "User ID", "Duration (ms)", "Client IP"}}
 	for _, entry := range entries {
 		table = append(table, []string{
 			util.FormatLocal(entry.Timestamp),
@@ -120,6 +120,7 @@ func (c AuditLogsCmd) Search(ctx context.Context, in AuditLogsSearchInput) error
 			strconv.FormatInt(entry.Status, 10),
 			entry.Path,
 			formatAuditLogUser(entry),
+			entry.UserID,
 			strconv.FormatInt(entry.DurationMs, 10),
 			entry.ClientIP,
 		})

--- a/cmd/audit_logs.go
+++ b/cmd/audit_logs.go
@@ -157,13 +157,10 @@ func parseAuditLogTime(value string) (time.Time, error) {
 }
 
 func formatAuditLogUser(entry kernel.AuditLogEntry) string {
-	if entry.Email != "" {
-		return entry.Email
+	if entry.Email == "" {
+		return "-"
 	}
-	if entry.UserID != "" {
-		return entry.UserID
-	}
-	return "-"
+	return entry.Email
 }
 
 func getAuditLogsHandler(cmd *cobra.Command) AuditLogsCmd {

--- a/cmd/audit_logs_test.go
+++ b/cmd/audit_logs_test.go
@@ -88,6 +88,7 @@ func TestAuditLogsSearchBuildsParamsAndPrintsTable(t *testing.T) {
 	assert.Contains(t, out, "POST")
 	assert.Contains(t, out, "201")
 	assert.Contains(t, out, "dev@example.com")
+	assert.Contains(t, out, "user_123")
 	assert.Contains(t, out, "203.0.113.7")
 }
 

--- a/cmd/audit_logs_test.go
+++ b/cmd/audit_logs_test.go
@@ -92,6 +92,13 @@ func TestAuditLogsSearchBuildsParamsAndPrintsTable(t *testing.T) {
 	assert.Contains(t, out, "203.0.113.7")
 }
 
+func TestFormatAuditLogUserDoesNotRepeatUserIDWhenEmailMissing(t *testing.T) {
+	entry := sampleAuditLogEntry("POST", "/browsers")
+	entry.Email = ""
+
+	assert.Equal(t, "-", formatAuditLogUser(entry))
+}
+
 func TestAuditLogsSearchRejectsInvalidStart(t *testing.T) {
 	c := AuditLogsCmd{auditLogs: &FakeAuditLogsService{}}
 


### PR DESCRIPTION
## Summary

- add a dedicated User ID column to the default audit log search table
- keep the User column email-only and show `-` when an email is unavailable instead of repeating the user ID
- cover the displayed user ID and missing-email fallback in tests

## Test plan

- `make test`
- `make build`
- `./bin/kernel audit-logs search --limit 3 --no-color`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only presentation change for audit log search; no API or auth behavior changes.
> 
> **Overview**
> **`kernel audit-logs search`** table output now has a dedicated **User ID** column populated from `entry.UserID`, so identifiers are visible even when an email is present.
> 
> The **User** column is **email-only**: it shows the address when available and **`-`** when it is not, instead of reusing the user ID in that column. JSON output is unchanged.
> 
> Tests assert **`user_123`** appears in search table output and that **`formatAuditLogUser`** returns **`-`** when email is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d0e97684f748f49f545c81f8eb1c9af0c98236e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->