### PR TITLE
Refresh brew tap before upgrading in kernel upgrade

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -98,18 +98,24 @@ func isOldTapError(stderr string) bool {
 	return strings.Contains(stderr, "brew tap kernel/tap")
 }
 
-// upgradeCommandArgs returns the command and arguments for a given installation method.
-// Returns nil if the method is unknown.
-func upgradeCommandArgs(method update.InstallMethod) []string {
+// upgradeCommandArgs returns the ordered commands to run for a given installation
+// method. Returns nil if the method is unknown.
+func upgradeCommandArgs(method update.InstallMethod) [][]string {
 	switch method {
 	case update.InstallMethodBrew:
-		return []string{"brew", "upgrade", "kernel/tap/kernel"}
+		// brew upgrade doesn't refresh the tap first, so a freshly released
+		// formula is invisible and the upgrade silently no-ops ("already
+		// installed"). Update the tap before upgrading.
+		return [][]string{
+			{"brew", "update"},
+			{"brew", "upgrade", "kernel/tap/kernel"},
+		}
 	case update.InstallMethodPNPM:
-		return []string{"pnpm", "add", "-g", "@onkernel/cli@latest"}
+		return [][]string{{"pnpm", "add", "-g", "@onkernel/cli@latest"}}
 	case update.InstallMethodNPM:
-		return []string{"npm", "i", "-g", "@onkernel/cli@latest"}
+		return [][]string{{"npm", "i", "-g", "@onkernel/cli@latest"}}
 	case update.InstallMethodBun:
-		return []string{"bun", "add", "-g", "@onkernel/cli@latest"}
+		return [][]string{{"bun", "add", "-g", "@onkernel/cli@latest"}}
 	default:
 		return nil
 	}
@@ -117,31 +123,37 @@ func upgradeCommandArgs(method update.InstallMethod) []string {
 
 // getUpgradeCommand returns the command string for display (e.g., dry-run output).
 func getUpgradeCommand(method update.InstallMethod) string {
-	args := upgradeCommandArgs(method)
-	if args == nil {
+	cmds := upgradeCommandArgs(method)
+	if cmds == nil {
 		return ""
 	}
-	return strings.Join(args, " ")
+	joined := make([]string, len(cmds))
+	for i, args := range cmds {
+		joined[i] = strings.Join(args, " ")
+	}
+	return strings.Join(joined, " && ")
 }
 
-// executeUpgrade runs the appropriate upgrade command based on the installation method.
-// Returns the captured stderr (for error diagnosis) and any error.
+// executeUpgrade runs the appropriate upgrade commands based on the installation
+// method. Returns the captured stderr (for error diagnosis) and any error.
 func executeUpgrade(method update.InstallMethod) (stderr string, err error) {
-	args := upgradeCommandArgs(method)
-	if args == nil {
+	cmds := upgradeCommandArgs(method)
+	if cmds == nil {
 		return "", fmt.Errorf("unknown installation method")
 	}
 
-	cmd := exec.Command(args[0], args[1:]...)
-	cmd.Stdout = os.Stdout
-	cmd.Stdin = os.Stdin
-
-	// Capture stderr while also displaying it to the user
 	var stderrBuf bytes.Buffer
-	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
-
-	err = cmd.Run()
-	return stderrBuf.String(), err
+	for _, args := range cmds {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Stdout = os.Stdout
+		cmd.Stdin = os.Stdin
+		// Capture stderr while also displaying it to the user
+		cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
+		if err = cmd.Run(); err != nil {
+			return stderrBuf.String(), err
+		}
+	}
+	return stderrBuf.String(), nil
 }
 
 // printManualUpgradeInstructions prints instructions for manually upgrading kernel

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/kernel/cli/pkg/update"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpgradeCommandArgs(t *testing.T) {
+	tests := []struct {
+		method   update.InstallMethod
+		expected [][]string
+	}{
+		{
+			// brew upgrade no-ops on a stale tap, so update must run first.
+			update.InstallMethodBrew,
+			[][]string{
+				{"brew", "update"},
+				{"brew", "upgrade", "kernel/tap/kernel"},
+			},
+		},
+		{update.InstallMethodNPM, [][]string{{"npm", "i", "-g", "@onkernel/cli@latest"}}},
+		{update.InstallMethodPNPM, [][]string{{"pnpm", "add", "-g", "@onkernel/cli@latest"}}},
+		{update.InstallMethodBun, [][]string{{"bun", "add", "-g", "@onkernel/cli@latest"}}},
+		{update.InstallMethodUnknown, nil},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.method), func(t *testing.T) {
+			assert.Equal(t, tt.expected, upgradeCommandArgs(tt.method))
+		})
+	}
+}
+
+func TestUpgradeCommandArgsBrewUpdatesBeforeUpgrade(t *testing.T) {
+	cmds := upgradeCommandArgs(update.InstallMethodBrew)
+	updateIdx, upgradeIdx := -1, -1
+	for i, args := range cmds {
+		if len(args) >= 2 && args[0] == "brew" && args[1] == "update" {
+			updateIdx = i
+		}
+		if len(args) >= 2 && args[0] == "brew" && args[1] == "upgrade" {
+			upgradeIdx = i
+		}
+	}
+	assert.NotEqual(t, -1, updateIdx, "expected a brew update step")
+	assert.NotEqual(t, -1, upgradeIdx, "expected a brew upgrade step")
+	assert.Less(t, updateIdx, upgradeIdx, "brew update must run before brew upgrade")
+}
+
+func TestGetUpgradeCommandBrew(t *testing.T) {
+	assert.Equal(t, "brew update && brew upgrade kernel/tap/kernel", getUpgradeCommand(update.InstallMethodBrew))
+	assert.Equal(t, "", getUpgradeCommand(update.InstallMethodUnknown))
+}

--- a/pkg/update/check.go
+++ b/pkg/update/check.go
@@ -434,7 +434,8 @@ func SuggestUpgradeCommand() string {
 func suggestUpgradeCommandForMethod(method InstallMethod) string {
 	switch method {
 	case InstallMethodBrew:
-		return "brew upgrade kernel/tap/kernel"
+		// brew upgrade alone can no-op on a stale tap, so refresh it first.
+		return "brew update && brew upgrade kernel/tap/kernel"
 	case InstallMethodPNPM:
 		return "pnpm add -g @onkernel/cli@latest"
 	case InstallMethodNPM:
@@ -442,7 +443,7 @@ func suggestUpgradeCommandForMethod(method InstallMethod) string {
 	case InstallMethodBun:
 		return "bun add -g @onkernel/cli@latest"
 	default:
-		return "brew upgrade kernel/tap/kernel"
+		return "brew update && brew upgrade kernel/tap/kernel"
 	}
 }
 

--- a/pkg/update/check_test.go
+++ b/pkg/update/check_test.go
@@ -11,11 +11,11 @@ func TestSuggestUpgradeCommandForMethod(t *testing.T) {
 		method   InstallMethod
 		expected string
 	}{
-		{InstallMethodBrew, "brew upgrade kernel/tap/kernel"},
+		{InstallMethodBrew, "brew update && brew upgrade kernel/tap/kernel"},
 		{InstallMethodNPM, "npm i -g @onkernel/cli@latest"},
 		{InstallMethodPNPM, "pnpm add -g @onkernel/cli@latest"},
 		{InstallMethodBun, "bun add -g @onkernel/cli@latest"},
-		{InstallMethodUnknown, "brew upgrade kernel/tap/kernel"},
+		{InstallMethodUnknown, "brew update && brew upgrade kernel/tap/kernel"},
 	}
 	for _, tt := range tests {
 		t.Run(string(tt.method), func(t *testing.T) {


### PR DESCRIPTION
## Summary

`kernel upgrade` detects a newer version from GitHub releases, then shells out to `brew upgrade kernel/tap/kernel`. But `brew upgrade` doesn't refresh the tap on its own, and Homebrew throttles its auto-update — so right after a release the local tap is stale, brew still sees the old formula, and the upgrade silently no-ops with "already installed" (exit 0). The user sees `kernel upgrade` announce a new version and then nothing changes.

Repro: release a new version, then on a machine whose tap hasn't refreshed run `kernel upgrade` → "New version available: X → Y" followed by "Warning: kernel/tap/kernel X already installed", no upgrade.

## Fix

- `kernel upgrade` now runs `brew update` before `brew upgrade kernel/tap/kernel` (brew method only; npm/pnpm/bun already pull `@latest`).
- `executeUpgrade`/`upgradeCommandArgs` refactored to run an ordered list of commands so the brew path can do two steps; stderr from all steps is still captured for the existing old-tap error diagnosis.
- The passive suggested-upgrade hint now shows `brew update && brew upgrade kernel/tap/kernel` for the same reason.

## Testing

`go build ./...`, `go vet`, `gofmt`, and `go test ./pkg/update/...` all pass (suggestion-string test updated).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only change to upgrade command sequencing and user-facing hints; no auth, data, or core runtime behavior beyond fixing stale-tap brew upgrades.
> 
> **Overview**
> Fixes **Homebrew upgrades silently doing nothing** right after a release when the local tap is stale: `kernel upgrade` now runs **`brew update` before `brew upgrade kernel/tap/kernel`** for the brew install path only.
> 
> Upgrade execution is refactored so each install method returns an **ordered list of shell commands** (`[][]string`). `executeUpgrade` runs them sequentially and still aggregates **stderr** across steps for the existing old-tap error handling. Dry-run / displayed commands use **`brew update && brew upgrade kernel/tap/kernel`**.
> 
> Passive upgrade hints in **`SuggestUpgradeCommand`** (brew and unknown-method fallback) use the same two-step brew string. Tests cover brew command ordering and the updated suggestion text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13320545f5f8cfa8c0570398eed9366c467615ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->