### PR TITLE
Support --asn for ISP proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ Per-category updates are partial — only categories you name are changed; other
   - `--city <name>` - City name (no spaces, e.g. sanfrancisco) (residential, mobile; requires `--country`)
   - `--state <code>` - Two-letter state code (residential, mobile)
   - `--zip <zip>` - US ZIP code (residential)
-  - `--asn <asn>` - Autonomous system number (e.g., AS15169) (residential)
+  - `--asn <asn>` - Autonomous system number, e.g. AS6079 (isp, residential). The ISP pool is a fixed set of static IPs, so only ASNs present in it can be requested; an unsupported value is rejected with the list of available ASNs.
   - `--os <os>` - Operating system: windows, macos, android (residential)
   - `--host <host>` - Proxy host (custom; required)
   - `--port <port>` - Proxy port (custom; required)
@@ -879,6 +879,9 @@ kernel proxies create --type custom --host proxy.example.com --port 8080 --ca-bu
 
 # Create a residential proxy with location and OS
 kernel proxies create --type residential --country US --city sanfrancisco --state CA --zip 94107 --asn AS15169 --os windows --name "SF Residential"
+
+# Create an ISP proxy pinned to a specific ASN
+kernel proxies create --type isp --asn AS6079 --name "RCN ISP"
 
 # Create a mobile proxy
 kernel proxies create --type mobile --country US --city sanfrancisco --name "US Mobile"

--- a/cmd/proxies/create.go
+++ b/cmd/proxies/create.go
@@ -49,6 +49,9 @@ func (p ProxyCmd) Create(ctx context.Context, in ProxyCreateInput) error {
 	// Build config based on type
 	switch proxyType {
 	case kernel.ProxyNewParamsTypeDatacenter:
+		if in.ASN != "" {
+			return fmt.Errorf("--asn is not supported for datacenter proxies")
+		}
 		config := kernel.ProxyNewParamsConfigDatacenter{}
 		if in.Country != "" {
 			config.Country = kernel.Opt(in.Country)
@@ -61,6 +64,9 @@ func (p ProxyCmd) Create(ctx context.Context, in ProxyCreateInput) error {
 		config := kernel.ProxyNewParamsConfigIsp{}
 		if in.Country != "" {
 			config.Country = kernel.Opt(in.Country)
+		}
+		if in.ASN != "" {
+			config.Asn = kernel.Opt(in.ASN)
 		}
 		params.Config = kernel.ProxyNewParamsConfigUnion{
 			OfIsp: &config,
@@ -109,8 +115,11 @@ func (p ProxyCmd) Create(ctx context.Context, in ProxyCreateInput) error {
 		if in.City != "" && in.Country == "" {
 			return fmt.Errorf("--country is required when --city is specified")
 		}
-		if in.Zip != "" || in.ASN != "" {
-			pterm.Warning.Println("--zip and --asn are not supported for mobile proxies and will be ignored")
+		if in.Zip != "" {
+			return fmt.Errorf("--zip is not supported for mobile proxies")
+		}
+		if in.ASN != "" {
+			return fmt.Errorf("--asn is not supported for mobile proxies")
 		}
 
 		if in.Country != "" {
@@ -127,6 +136,9 @@ func (p ProxyCmd) Create(ctx context.Context, in ProxyCreateInput) error {
 		}
 
 	case kernel.ProxyNewParamsTypeCustom:
+		if in.ASN != "" {
+			return fmt.Errorf("--asn is not supported for custom proxies; the upstream proxy determines the egress network")
+		}
 		if in.Host == "" {
 			return fmt.Errorf("--host is required for custom proxy type")
 		}

--- a/cmd/proxies/create.go
+++ b/cmd/proxies/create.go
@@ -66,7 +66,10 @@ func (p ProxyCmd) Create(ctx context.Context, in ProxyCreateInput) error {
 			config.Country = kernel.Opt(in.Country)
 		}
 		if in.ASN != "" {
-			config.Asn = kernel.Opt(in.ASN)
+			// The generated ISP config has no Asn field until Stainless regenerates
+			// against the spec. Send it as an extra field so the flag works against
+			// the deployed API now; replace with config.Asn on the next SDK bump.
+			config.SetExtraFields(map[string]any{"asn": in.ASN})
 		}
 		params.Config = kernel.ProxyNewParamsConfigUnion{
 			OfIsp: &config,

--- a/cmd/proxies/create_asn_test.go
+++ b/cmd/proxies/create_asn_test.go
@@ -2,6 +2,7 @@ package proxies
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/kernel/kernel-go-sdk"
@@ -10,6 +11,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// The ASN currently travels as an extra field rather than a generated one, so assert on
+// the serialized request: that is what the API sees, and it stays valid once the field
+// becomes typed.
+func ispConfigJSON(t *testing.T, body kernel.ProxyNewParams) map[string]any {
+	t.Helper()
+
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	var decoded struct {
+		Config map[string]any `json:"config"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	return decoded.Config
+}
+
 func TestProxyCreate_ISP_SendsASN(t *testing.T) {
 	captureOutput(t)
 
@@ -17,9 +34,7 @@ func TestProxyCreate_ISP_SendsASN(t *testing.T) {
 	fake := &FakeProxyService{
 		NewFunc: func(ctx context.Context, body kernel.ProxyNewParams, opts ...option.RequestOption) (*kernel.ProxyNewResponse, error) {
 			called = true
-			ispConfig := body.Config.OfIsp
-			require.NotNil(t, ispConfig)
-			assert.Equal(t, "AS6079", ispConfig.Asn.Value)
+			assert.Equal(t, "AS6079", ispConfigJSON(t, body)["asn"])
 
 			return &kernel.ProxyNewResponse{ID: "isp-new", Name: "RCN ISP", Type: kernel.ProxyNewResponseTypeIsp}, nil
 		},
@@ -36,6 +51,29 @@ func TestProxyCreate_ISP_SendsASN(t *testing.T) {
 	assert.True(t, called, "expected the create request to be sent")
 }
 
+func TestProxyCreate_ISP_SendsASNAlongsideCountry(t *testing.T) {
+	captureOutput(t)
+
+	fake := &FakeProxyService{
+		NewFunc: func(ctx context.Context, body kernel.ProxyNewParams, opts ...option.RequestOption) (*kernel.ProxyNewResponse, error) {
+			config := ispConfigJSON(t, body)
+			assert.Equal(t, "AS6079", config["asn"])
+			assert.Equal(t, "US", config["country"], "the extra field must not displace country")
+
+			return &kernel.ProxyNewResponse{ID: "isp-new", Name: "RCN ISP", Type: kernel.ProxyNewResponseTypeIsp}, nil
+		},
+	}
+
+	p := ProxyCmd{proxies: fake}
+	err := p.Create(context.Background(), ProxyCreateInput{
+		Name:    "RCN ISP",
+		Type:    "isp",
+		Country: "US",
+		ASN:     "AS6079",
+	})
+	require.NoError(t, err)
+}
+
 // Omitting --asn must not start sending an empty ASN, which the API would reject as
 // malformed rather than treating as "no preference".
 func TestProxyCreate_ISP_OmitsEmptyASN(t *testing.T) {
@@ -43,9 +81,8 @@ func TestProxyCreate_ISP_OmitsEmptyASN(t *testing.T) {
 
 	fake := &FakeProxyService{
 		NewFunc: func(ctx context.Context, body kernel.ProxyNewParams, opts ...option.RequestOption) (*kernel.ProxyNewResponse, error) {
-			ispConfig := body.Config.OfIsp
-			require.NotNil(t, ispConfig)
-			assert.False(t, ispConfig.Asn.Valid(), "asn should be absent when not requested")
+			_, present := ispConfigJSON(t, body)["asn"]
+			assert.False(t, present, "asn should be absent when not requested")
 
 			return &kernel.ProxyNewResponse{ID: "isp-new", Name: "Any ISP", Type: kernel.ProxyNewResponseTypeIsp}, nil
 		},

--- a/cmd/proxies/create_asn_test.go
+++ b/cmd/proxies/create_asn_test.go
@@ -1,0 +1,104 @@
+package proxies
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kernel/kernel-go-sdk"
+	"github.com/kernel/kernel-go-sdk/option"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProxyCreate_ISP_SendsASN(t *testing.T) {
+	captureOutput(t)
+
+	called := false
+	fake := &FakeProxyService{
+		NewFunc: func(ctx context.Context, body kernel.ProxyNewParams, opts ...option.RequestOption) (*kernel.ProxyNewResponse, error) {
+			called = true
+			ispConfig := body.Config.OfIsp
+			require.NotNil(t, ispConfig)
+			assert.Equal(t, "AS6079", ispConfig.Asn.Value)
+
+			return &kernel.ProxyNewResponse{ID: "isp-new", Name: "RCN ISP", Type: kernel.ProxyNewResponseTypeIsp}, nil
+		},
+	}
+
+	p := ProxyCmd{proxies: fake}
+	err := p.Create(context.Background(), ProxyCreateInput{
+		Name: "RCN ISP",
+		Type: "isp",
+		ASN:  "AS6079",
+	})
+
+	require.NoError(t, err)
+	assert.True(t, called, "expected the create request to be sent")
+}
+
+// Omitting --asn must not start sending an empty ASN, which the API would reject as
+// malformed rather than treating as "no preference".
+func TestProxyCreate_ISP_OmitsEmptyASN(t *testing.T) {
+	captureOutput(t)
+
+	fake := &FakeProxyService{
+		NewFunc: func(ctx context.Context, body kernel.ProxyNewParams, opts ...option.RequestOption) (*kernel.ProxyNewResponse, error) {
+			ispConfig := body.Config.OfIsp
+			require.NotNil(t, ispConfig)
+			assert.False(t, ispConfig.Asn.Valid(), "asn should be absent when not requested")
+
+			return &kernel.ProxyNewResponse{ID: "isp-new", Name: "Any ISP", Type: kernel.ProxyNewResponseTypeIsp}, nil
+		},
+	}
+
+	p := ProxyCmd{proxies: fake}
+	err := p.Create(context.Background(), ProxyCreateInput{Name: "Any ISP", Type: "isp"})
+	require.NoError(t, err)
+}
+
+// The flag is registered on every type, so the types that cannot honour it have to say so
+// rather than drop it and hand back a proxy on an arbitrary network.
+func TestProxyCreate_ASNRejectedForUnsupportedTypes(t *testing.T) {
+	tests := []struct {
+		proxyType string
+		input     ProxyCreateInput
+	}{
+		{"datacenter", ProxyCreateInput{Name: "dc", Type: "datacenter", ASN: "AS6079"}},
+		{"mobile", ProxyCreateInput{Name: "mob", Type: "mobile", Country: "US", ASN: "AS6079"}},
+		{"custom", ProxyCreateInput{Name: "cus", Type: "custom", Host: "proxy.example.com", Port: 8080, ASN: "AS6079"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.proxyType, func(t *testing.T) {
+			captureOutput(t)
+
+			fake := &FakeProxyService{
+				NewFunc: func(ctx context.Context, body kernel.ProxyNewParams, opts ...option.RequestOption) (*kernel.ProxyNewResponse, error) {
+					require.Failf(t, "unexpected request", "create should not be attempted for %s with --asn", tt.proxyType)
+					return nil, nil
+				},
+			}
+
+			p := ProxyCmd{proxies: fake}
+			err := p.Create(context.Background(), tt.input)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "--asn is not supported")
+		})
+	}
+}
+
+func TestProxyCreate_ZipRejectedForMobile(t *testing.T) {
+	captureOutput(t)
+
+	fake := &FakeProxyService{
+		NewFunc: func(ctx context.Context, body kernel.ProxyNewParams, opts ...option.RequestOption) (*kernel.ProxyNewResponse, error) {
+			require.Fail(t, "unexpected request", "create should not be attempted for mobile with --zip")
+			return nil, nil
+		},
+	}
+
+	p := ProxyCmd{proxies: fake}
+	err := p.Create(context.Background(), ProxyCreateInput{Name: "mob", Type: "mobile", Country: "US", Zip: "94107"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--zip is not supported")
+}

--- a/cmd/proxies/proxies.go
+++ b/cmd/proxies/proxies.go
@@ -110,7 +110,7 @@ func init() {
 	proxiesCreateCmd.Flags().String("city", "", "City name (no spaces, e.g. sanfrancisco)")
 	proxiesCreateCmd.Flags().String("state", "", "Two-letter state code")
 	proxiesCreateCmd.Flags().String("zip", "", "US ZIP code")
-	proxiesCreateCmd.Flags().String("asn", "", "Autonomous system number (e.g. AS15169)")
+	proxiesCreateCmd.Flags().String("asn", "", "Autonomous system number, e.g. AS6079 (isp, residential)")
 
 	// OS flag (residential)
 	proxiesCreateCmd.Flags().String("os", "", "Operating system (windows|macos|android)")


### PR DESCRIPTION
## Problem

`kernel proxy create --type isp --name ulzii-asn --asn AS6079` returned a proxy on AS11426, not AS6079, and said nothing about it.

`--asn` is registered on the `create` command for every type, but was only wired into the request for `residential` and `mobile`. The `isp` branch built a config containing `country` and nothing else, so the flag never left the machine. The types that genuinely can't honour it were no better: `datacenter` and `custom` ignored it entirely, and `mobile` printed a warning and continued.

## Change

- `--asn` now flows into the ISP config.
- `datacenter`, `custom`, and `mobile` fail with a clear error rather than dropping the flag. Mobile previously warned and continued for `--zip`/`--asn`; the API rejects both, so the CLI now matches instead of building a request the server will refuse.
- Flag help and README updated, including an ISP example.

Server-side support is kernel/kernel#3059, which validates the ASN against the pool and returns the available ASNs when it isn't there.

## On the extra field

`ProxyNewParamsConfigIsp` in the pinned SDK (v0.85.0) has no `Asn` field yet — Stainless only regenerates once the spec change in kernel/kernel#3059 merges. Rather than block this PR on that release, the ASN is sent via `SetExtraFields`, which produces an identical request body:

```json
{"type":"isp","name":"RCN ISP","config":{"country":"US","asn":"AS6079"}}
```

This is marked with a comment to swap for `config.Asn` on the next SDK bump. The tests assert on the **serialized request** rather than the struct field, so they keep verifying the wire format unchanged once `asn` becomes generated.

Ordering note: this is safe to merge before or after #3059. Until the API side ships, `--asn` on an ISP proxy is simply ignored by the server, which is today's behaviour.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean against the unpatched SDK v0.85.0
- [x] `go test ./...` — full suite passes
- [x] Wire format verified directly against the real SDK: `config.asn` is present and does not displace `country`
- [x] New tests: ISP sends the ASN; ASN coexists with `--country`; ISP omits it when not requested (so an empty string is never sent, which the API would reject as malformed); datacenter/mobile/custom reject `--asn` without issuing a request; mobile rejects `--zip`
- [ ] Follow-up after the SDK bump: replace `SetExtraFields` with `config.Asn`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only proxy create validation and request shaping; no auth or infrastructure changes, with tests locking the wire format.
> 
> **Overview**
> **`kernel proxies create --asn` now reaches the API for ISP proxies** instead of being dropped on the floor. The value is sent on the ISP config via `SetExtraFields` until the Go SDK gains a typed `Asn` field.
> 
> **Unsupported proxy types no longer silently ignore the flag.** Datacenter, custom, and mobile return a clear error if `--asn` is set; mobile also errors on `--zip` instead of warning and continuing with a request the API would reject.
> 
> README and `--asn` flag help are updated (ISP/residential scope, pool constraints), with an ISP create example. New tests cover ISP wire format, omission when unset, and rejection paths for unsupported types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac173c599e35cf0d950129e9cac785828b290c1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->