### PR TITLE
Update stagehand template to v4

### DIFF
--- a/pkg/templates/typescript/stagehand/.env.example
+++ b/pkg/templates/typescript/stagehand/.env.example
@@ -1,4 +1,4 @@
-# Copy this file to .env and fill in your API key.
-# Defaults to OpenAI. To use another provider, also set MODEL (with a provider prefix),
-# e.g. MODEL=google/gemini-2.5-flash
-MODEL_API_KEY=your_openai_api_key_here
+# Copy this file to .env and set the model and its API key.
+# MODEL is provider-prefixed, e.g. anthropic/claude-sonnet-4-5, openai/gpt-4.1, google/gemini-2.5-flash
+MODEL=anthropic/claude-sonnet-4-5
+MODEL_API_KEY=your_api_key_here

--- a/pkg/templates/typescript/stagehand/.env.example
+++ b/pkg/templates/typescript/stagehand/.env.example
@@ -1,2 +1,4 @@
-# Copy this file to .env and fill in your API key
-OPENAI_API_KEY=your_openai_api_key_here
+# Copy this file to .env and fill in your API key.
+# Defaults to OpenAI. To use another provider, also set MODEL (with a provider prefix),
+# e.g. MODEL=google/gemini-2.5-flash
+MODEL_API_KEY=your_openai_api_key_here

--- a/pkg/templates/typescript/stagehand/README.md
+++ b/pkg/templates/typescript/stagehand/README.md
@@ -1,10 +1,19 @@
-# Kernel TypeScript Sample App - Stagehand
+# Kernel TypeScript Sample App - Stagehand (v4)
 
-A Stagehand-powered browser automation app that extracts team size information from Y Combinator company pages.
+A [Stagehand v4](https://docs.stagehand.dev) browser automation app that extracts team size information from Y Combinator company pages, running against a Kernel cloud browser.
 
 ## What it does
 
 The `teamsize-task` searches for a startup on Y Combinator's company directory and extracts the team size (number of employees).
+
+## How Stagehand v4 connects to a Kernel browser
+
+Stagehand v4 no longer drives the browser purely over CDP — it runs as a **Chrome extension** next to the browser. To use it with a remote Kernel browser, this template:
+
+1. Uploads the Stagehand extension (shipped inside the `@browserbasehq/stagehand` package) to your Kernel project once.
+2. Creates the Kernel browser with that extension preloaded (`extensions: [{ name }]`).
+3. Reads the extension's runtime id off its service worker over CDP.
+4. Connects with `localBrowser.connect({ cdpUrl, extensionId })` and `Stagehand.create({ browser })`.
 
 ## Input
 
@@ -24,10 +33,17 @@ The `teamsize-task` searches for a startup on Y Combinator's company directory a
 
 ## Setup
 
-Create a `.env` file:
+Create a `.env` file (defaults to OpenAI):
 
 ```
-OPENAI_API_KEY=your-openai-api-key
+MODEL_API_KEY=your-openai-api-key
+```
+
+To use a different provider, also set `MODEL` (with a provider prefix):
+
+```
+MODEL=google/gemini-2.5-flash
+MODEL_API_KEY=your-gemini-api-key
 ```
 
 ## Deploy

--- a/pkg/templates/typescript/stagehand/README.md
+++ b/pkg/templates/typescript/stagehand/README.md
@@ -11,8 +11,8 @@ The `teamsize-task` searches for a startup on Y Combinator's company directory a
 Stagehand v4 no longer drives the browser purely over CDP — it runs as a **Chrome extension** next to the browser. To use it with a remote Kernel browser, this template:
 
 1. Uploads the Stagehand extension (shipped inside the `@browserbasehq/stagehand` package) to your Kernel project once.
-2. Creates the Kernel browser with that extension preloaded (`extensions: [{ name }]`).
-3. Reads the extension's runtime id off its service worker over CDP.
+2. Creates the Kernel browser with that extension preloaded (`extensions: [{ id }]`).
+3. Derives the extension's Chrome runtime id from the Kernel extension id (Chrome computes it from the load path).
 4. Connects with `localBrowser.connect({ cdpUrl, extensionId })` and `Stagehand.create({ browser })`.
 
 ## Input

--- a/pkg/templates/typescript/stagehand/README.md
+++ b/pkg/templates/typescript/stagehand/README.md
@@ -10,10 +10,9 @@ The `teamsize-task` searches for a startup on Y Combinator's company directory a
 
 Stagehand v4 no longer drives the browser purely over CDP — it runs as a **Chrome extension** next to the browser. To use it with a remote Kernel browser, this template:
 
-1. Uploads the Stagehand extension (shipped inside the `@browserbasehq/stagehand` package) to your Kernel project once.
-2. Creates the Kernel browser with that extension preloaded (`extensions: [{ id }]`).
-3. Derives the extension's Chrome runtime id from the Kernel extension id (Chrome computes it from the load path).
-4. Connects with `localBrowser.connect({ cdpUrl, extensionId })` and `Stagehand.create({ browser })`.
+1. Creates a Kernel browser.
+2. Uploads the Stagehand extension (shipped inside the `@browserbasehq/stagehand` package) onto the running browser's filesystem, at the path Stagehand loads it from.
+3. Connects with `localBrowser.connect({ cdpUrl })` — with no `extensionId`, Stagehand loads the extension into the running browser over CDP (`Extensions.loadUnpacked`) — and `Stagehand.create({ browser })`.
 
 ## Input
 

--- a/pkg/templates/typescript/stagehand/README.md
+++ b/pkg/templates/typescript/stagehand/README.md
@@ -32,18 +32,14 @@ Stagehand v4 no longer drives the browser purely over CDP — it runs as a **Chr
 
 ## Setup
 
-Create a `.env` file (defaults to OpenAI):
+Create a `.env` file with a provider-prefixed `MODEL` and its API key:
 
 ```
-MODEL_API_KEY=your-openai-api-key
+MODEL=anthropic/claude-sonnet-4-5
+MODEL_API_KEY=your-api-key
 ```
 
-To use a different provider, also set `MODEL` (with a provider prefix):
-
-```
-MODEL=google/gemini-2.5-flash
-MODEL_API_KEY=your-gemini-api-key
-```
+`MODEL` can be any provider Stagehand supports, e.g. `openai/gpt-4.1` or `google/gemini-2.5-flash`.
 
 ## Deploy
 

--- a/pkg/templates/typescript/stagehand/index.ts
+++ b/pkg/templates/typescript/stagehand/index.ts
@@ -1,6 +1,5 @@
 import { Stagehand, localBrowser, type ModelName } from "@browserbasehq/stagehand";
 import { Kernel, type KernelContext } from "@onkernel/sdk";
-import { createHash } from "node:crypto";
 import { createReadStream } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -29,43 +28,15 @@ if (!MODEL_API_KEY) {
   throw new Error("MODEL_API_KEY (or OPENAI_API_KEY) is not set");
 }
 
-// Stagehand v4 runs as a Chrome extension alongside the browser. When connecting
-// to a remote Kernel browser over CDP we preload that extension at browser
-// creation and hand its runtime id to `localBrowser.connect`.
-const STAGEHAND_EXTENSION_NAME = "stagehand-runtime";
-
-// The extension archive ships inside the installed @browserbasehq/stagehand package.
+// Stagehand v4 runs as a Chrome extension alongside the browser. When
+// `localBrowser.connect` is called without an `extensionId`, Stagehand loads the
+// extension into the running browser over CDP via `Extensions.loadUnpacked`,
+// reading it from an absolute path on the *browser's* filesystem. Both the
+// unpacked extension and its archive ship inside the installed
+// @browserbasehq/stagehand package.
 const stagehandDist = dirname(fileURLToPath(import.meta.resolve("@browserbasehq/stagehand")));
 const STAGEHAND_EXTENSION_ZIP = join(stagehandDist, "assets/stagehand-extension.zip");
-
-// Upload the Stagehand extension to the project once and reuse it thereafter,
-// returning the Kernel extension id.
-async function ensureStagehandExtension(): Promise<string> {
-  const existing = await kernel.extensions.list();
-  const extension = existing.find((ext) => ext.name === STAGEHAND_EXTENSION_NAME);
-  if (extension) return extension.id;
-
-  const uploaded = await kernel.extensions.upload({
-    file: createReadStream(STAGEHAND_EXTENSION_ZIP),
-    name: STAGEHAND_EXTENSION_NAME,
-  });
-  return uploaded.id;
-}
-
-// Chrome derives an unpacked extension's runtime id from the absolute path it is
-// loaded from. Kernel extracts a preloaded extension to
-// `/home/kernel/extensions/<kernel-extension-id>`, so we can compute the runtime
-// id directly instead of discovering it over CDP: SHA-256 the path, take the
-// first 16 bytes, and map each nibble to a..p. This holds because the Stagehand
-// extension ships without a manifest `key` (a keyed manifest would pin the id).
-function chromeExtensionId(kernelExtensionId: string): string {
-  const extensionPath = `/home/kernel/extensions/${kernelExtensionId}`;
-  const digest = createHash("sha256").update(extensionPath).digest().subarray(0, 16);
-  return [...digest]
-    .flatMap((byte) => [byte >> 4, byte & 0xf])
-    .map((nibble) => String.fromCharCode("a".charCodeAt(0) + nibble))
-    .join("");
-}
+const STAGEHAND_EXTENSION_DIR = join(stagehandDist, "extension");
 
 app.action<CompanyInput, TeamSizeOutput>(
   "teamsize-task",
@@ -81,25 +52,29 @@ app.action<CompanyInput, TeamSizeOutput>(
 
     const company = payload?.company || "kernel";
 
-    const kernelExtensionId = await ensureStagehandExtension();
-    const extensionId = chromeExtensionId(kernelExtensionId);
-
     const kernelBrowser = await kernel.browsers.create({
       invocation_id: ctx.invocation_id,
       stealth: true,
-      extensions: [{ id: kernelExtensionId }],
     });
 
     console.log("Kernel browser live view url: ", kernelBrowser.browser_live_view_url);
+
+    // Mirror the Stagehand extension onto the running browser's filesystem at the
+    // exact path Stagehand loads it from, so the `Extensions.loadUnpacked` call
+    // made by `localBrowser.connect` (below) finds it.
+    await kernel.browsers.fs.uploadZip(kernelBrowser.session_id, {
+      dest_path: STAGEHAND_EXTENSION_DIR,
+      zip_file: createReadStream(STAGEHAND_EXTENSION_ZIP),
+    });
 
     // Stagehand only closes browsers it launched, so we close the connection and
     // delete the Kernel browser ourselves, even if the automation throws.
     let stagehand: Awaited<ReturnType<typeof Stagehand.create>> | undefined;
     let browser: Awaited<ReturnType<typeof localBrowser.connect>> | undefined;
     try {
+      // No `extensionId`: Stagehand loads the mirrored extension over CDP.
       browser = await localBrowser.connect({
         cdpUrl: kernelBrowser.cdp_ws_url,
-        extensionId,
       });
       stagehand = await Stagehand.create({
         browser,

--- a/pkg/templates/typescript/stagehand/index.ts
+++ b/pkg/templates/typescript/stagehand/index.ts
@@ -1,9 +1,9 @@
 import { Stagehand, localBrowser, type ModelName } from "@browserbasehq/stagehand";
 import { Kernel, type KernelContext } from "@onkernel/sdk";
+import { createHash } from "node:crypto";
 import { createReadStream } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { WebSocket } from "ws";
 // Stagehand v4 uses zod v4 schema types.
 import { z } from "zod";
 
@@ -38,66 +38,33 @@ const STAGEHAND_EXTENSION_NAME = "stagehand-runtime";
 const stagehandDist = dirname(fileURLToPath(import.meta.resolve("@browserbasehq/stagehand")));
 const STAGEHAND_EXTENSION_ZIP = join(stagehandDist, "assets/stagehand-extension.zip");
 
-// Upload the Stagehand extension to the project once and reuse it thereafter.
+// Upload the Stagehand extension to the project once and reuse it thereafter,
+// returning the Kernel extension id.
 async function ensureStagehandExtension(): Promise<string> {
   const existing = await kernel.extensions.list();
-  for (const ext of existing) {
-    if (ext.name === STAGEHAND_EXTENSION_NAME) return STAGEHAND_EXTENSION_NAME;
-  }
-  await kernel.extensions.upload({
+  const extension = existing.find((ext) => ext.name === STAGEHAND_EXTENSION_NAME);
+  if (extension) return extension.id;
+
+  const uploaded = await kernel.extensions.upload({
     file: createReadStream(STAGEHAND_EXTENSION_ZIP),
     name: STAGEHAND_EXTENSION_NAME,
   });
-  return STAGEHAND_EXTENSION_NAME;
+  return uploaded.id;
 }
 
-// Chrome assigns the preloaded extension a runtime id. Read it off the extension's
-// service worker target so we can attach Stagehand to it.
-async function discoverExtensionId(cdpUrl: string, timeoutMs = 20_000): Promise<string> {
-  return await new Promise<string>((resolve, reject) => {
-    const ws = new WebSocket(cdpUrl);
-    let settled = false;
-    let messageId = 0;
-
-    const finish = (error: Error | null, id?: string) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      clearInterval(poller);
-      ws.close();
-      error ? reject(error) : resolve(id!);
-    };
-
-    const poll = () => {
-      if (ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({ id: ++messageId, method: "Target.getTargets" }));
-      }
-    };
-    const timer = setTimeout(
-      () => finish(new Error("Timed out waiting for the Stagehand extension service worker")),
-      timeoutMs,
-    );
-    const poller = setInterval(poll, 500);
-
-    ws.on("open", poll);
-    ws.on("error", (error: Error) => finish(error));
-    ws.on("close", () => finish(new Error("CDP socket closed before the Stagehand extension was found")));
-    ws.on("message", (buf: Buffer) => {
-      let targets: Array<{ type: string; url: string }> | undefined;
-      try {
-        targets = JSON.parse(buf.toString()).result?.targetInfos;
-      } catch {
-        return;
-      }
-      const worker = targets?.find(
-        (t) =>
-          t.type === "service_worker" &&
-          t.url.startsWith("chrome-extension://") &&
-          t.url.includes("service-worker.js"),
-      );
-      if (worker) finish(null, worker.url.split("/")[2]);
-    });
-  });
+// Chrome derives an unpacked extension's runtime id from the absolute path it is
+// loaded from. Kernel extracts a preloaded extension to
+// `/home/kernel/extensions/<kernel-extension-id>`, so we can compute the runtime
+// id directly instead of discovering it over CDP: SHA-256 the path, take the
+// first 16 bytes, and map each nibble to a..p. This holds because the Stagehand
+// extension ships without a manifest `key` (a keyed manifest would pin the id).
+function chromeExtensionId(kernelExtensionId: string): string {
+  const extensionPath = `/home/kernel/extensions/${kernelExtensionId}`;
+  const digest = createHash("sha256").update(extensionPath).digest().subarray(0, 16);
+  return [...digest]
+    .flatMap((byte) => [byte >> 4, byte & 0xf])
+    .map((nibble) => String.fromCharCode("a".charCodeAt(0) + nibble))
+    .join("");
 }
 
 app.action<CompanyInput, TeamSizeOutput>(
@@ -114,12 +81,13 @@ app.action<CompanyInput, TeamSizeOutput>(
 
     const company = payload?.company || "kernel";
 
-    const extensionName = await ensureStagehandExtension();
+    const kernelExtensionId = await ensureStagehandExtension();
+    const extensionId = chromeExtensionId(kernelExtensionId);
 
     const kernelBrowser = await kernel.browsers.create({
       invocation_id: ctx.invocation_id,
       stealth: true,
-      extensions: [{ name: extensionName }],
+      extensions: [{ id: kernelExtensionId }],
     });
 
     console.log("Kernel browser live view url: ", kernelBrowser.browser_live_view_url);
@@ -129,8 +97,6 @@ app.action<CompanyInput, TeamSizeOutput>(
     let stagehand: Awaited<ReturnType<typeof Stagehand.create>> | undefined;
     let browser: Awaited<ReturnType<typeof localBrowser.connect>> | undefined;
     try {
-      const extensionId = await discoverExtensionId(kernelBrowser.cdp_ws_url);
-
       browser = await localBrowser.connect({
         cdpUrl: kernelBrowser.cdp_ws_url,
         extensionId,

--- a/pkg/templates/typescript/stagehand/index.ts
+++ b/pkg/templates/typescript/stagehand/index.ts
@@ -16,14 +16,15 @@ interface TeamSizeOutput {
   teamSize: string;
 }
 
-// LLM API Keys are set in the environment during `kernel deploy <filename> -e MODEL_API_KEY=XXX`
+// Set MODEL (provider-prefixed, e.g. anthropic/claude-sonnet-4-5, openai/gpt-4.1,
+// google/gemini-2.5-flash) and MODEL_API_KEY for that provider in the environment
+// during `kernel deploy <filename> -e MODEL=XXX -e MODEL_API_KEY=YYY`.
 // See https://www.kernel.sh/docs/apps/deploy#environment-variables
-// Defaults to OpenAI. Override MODEL to use another provider (e.g. google/gemini-2.5-flash).
-const MODEL = (process.env.MODEL ?? "openai/gpt-4.1") as ModelName;
+const MODEL = process.env.MODEL as ModelName | undefined;
 const MODEL_API_KEY = process.env.MODEL_API_KEY;
 
-if (!MODEL_API_KEY) {
-  throw new Error("MODEL_API_KEY is not set");
+if (!MODEL || !MODEL_API_KEY) {
+  throw new Error("MODEL and MODEL_API_KEY must be set");
 }
 
 app.action<CompanyInput, TeamSizeOutput>(

--- a/pkg/templates/typescript/stagehand/index.ts
+++ b/pkg/templates/typescript/stagehand/index.ts
@@ -1,10 +1,8 @@
 import { Stagehand, localBrowser, type ModelName } from "@browserbasehq/stagehand";
 import { Kernel, type KernelContext } from "@onkernel/sdk";
-import { createReadStream } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
 // Stagehand v4 uses zod v4 schema types.
 import { z } from "zod";
+import { loadStagehandExtension } from "./stagehand-extension";
 
 const kernel = new Kernel();
 
@@ -27,16 +25,6 @@ const MODEL_API_KEY = process.env.MODEL_API_KEY ?? process.env.OPENAI_API_KEY;
 if (!MODEL_API_KEY) {
   throw new Error("MODEL_API_KEY (or OPENAI_API_KEY) is not set");
 }
-
-// Stagehand v4 runs as a Chrome extension alongside the browser. When
-// `localBrowser.connect` is called without an `extensionId`, Stagehand loads the
-// extension into the running browser over CDP via `Extensions.loadUnpacked`,
-// reading it from an absolute path on the *browser's* filesystem. Both the
-// unpacked extension and its archive ship inside the installed
-// @browserbasehq/stagehand package.
-const stagehandDist = dirname(fileURLToPath(import.meta.resolve("@browserbasehq/stagehand")));
-const STAGEHAND_EXTENSION_ZIP = join(stagehandDist, "assets/stagehand-extension.zip");
-const STAGEHAND_EXTENSION_DIR = join(stagehandDist, "extension");
 
 app.action<CompanyInput, TeamSizeOutput>(
   "teamsize-task",
@@ -64,15 +52,9 @@ app.action<CompanyInput, TeamSizeOutput>(
     let stagehand: Awaited<ReturnType<typeof Stagehand.create>> | undefined;
     let browser: Awaited<ReturnType<typeof localBrowser.connect>> | undefined;
     try {
-      // Mirror the Stagehand extension onto the running browser's filesystem at
-      // the exact path Stagehand loads it from, so the `Extensions.loadUnpacked`
-      // call made by `localBrowser.connect` (below) finds it.
-      await kernel.browsers.fs.uploadZip(kernelBrowser.session_id, {
-        dest_path: STAGEHAND_EXTENSION_DIR,
-        zip_file: createReadStream(STAGEHAND_EXTENSION_ZIP),
-      });
-
-      // No `extensionId`: Stagehand loads the mirrored extension over CDP.
+      // Load the Stagehand extension into the running browser. With no
+      // `extensionId`, `localBrowser.connect` then loads it over CDP.
+      await loadStagehandExtension(kernel, kernelBrowser.session_id);
       browser = await localBrowser.connect({
         cdpUrl: kernelBrowser.cdp_ws_url,
       });

--- a/pkg/templates/typescript/stagehand/index.ts
+++ b/pkg/templates/typescript/stagehand/index.ts
@@ -59,19 +59,19 @@ app.action<CompanyInput, TeamSizeOutput>(
 
     console.log("Kernel browser live view url: ", kernelBrowser.browser_live_view_url);
 
-    // Mirror the Stagehand extension onto the running browser's filesystem at the
-    // exact path Stagehand loads it from, so the `Extensions.loadUnpacked` call
-    // made by `localBrowser.connect` (below) finds it.
-    await kernel.browsers.fs.uploadZip(kernelBrowser.session_id, {
-      dest_path: STAGEHAND_EXTENSION_DIR,
-      zip_file: createReadStream(STAGEHAND_EXTENSION_ZIP),
-    });
-
     // Stagehand only closes browsers it launched, so we close the connection and
     // delete the Kernel browser ourselves, even if the automation throws.
     let stagehand: Awaited<ReturnType<typeof Stagehand.create>> | undefined;
     let browser: Awaited<ReturnType<typeof localBrowser.connect>> | undefined;
     try {
+      // Mirror the Stagehand extension onto the running browser's filesystem at
+      // the exact path Stagehand loads it from, so the `Extensions.loadUnpacked`
+      // call made by `localBrowser.connect` (below) finds it.
+      await kernel.browsers.fs.uploadZip(kernelBrowser.session_id, {
+        dest_path: STAGEHAND_EXTENSION_DIR,
+        zip_file: createReadStream(STAGEHAND_EXTENSION_ZIP),
+      });
+
       // No `extensionId`: Stagehand loads the mirrored extension over CDP.
       browser = await localBrowser.connect({
         cdpUrl: kernelBrowser.cdp_ws_url,

--- a/pkg/templates/typescript/stagehand/index.ts
+++ b/pkg/templates/typescript/stagehand/index.ts
@@ -83,9 +83,16 @@ app.action<CompanyInput, TeamSizeOutput>(
 
       return data;
     } finally {
-      await stagehand?.close();
-      await browser?.close();
-      await kernel.browsers.deleteByID(kernelBrowser.session_id);
+      // Nested so a rejected close() never skips deleting the Kernel browser.
+      try {
+        await stagehand?.close();
+      } finally {
+        try {
+          await browser?.close();
+        } finally {
+          await kernel.browsers.deleteByID(kernelBrowser.session_id);
+        }
+      }
     }
   },
 );

--- a/pkg/templates/typescript/stagehand/index.ts
+++ b/pkg/templates/typescript/stagehand/index.ts
@@ -56,31 +56,46 @@ async function ensureStagehandExtension(): Promise<string> {
 async function discoverExtensionId(cdpUrl: string, timeoutMs = 20_000): Promise<string> {
   return await new Promise<string>((resolve, reject) => {
     const ws = new WebSocket(cdpUrl);
-    const deadline = Date.now() + timeoutMs;
+    let settled = false;
     let messageId = 0;
 
-    const poll = () => ws.send(JSON.stringify({ id: ++messageId, method: "Target.getTargets" }));
+    const finish = (error: Error | null, id?: string) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      clearInterval(poller);
+      ws.close();
+      error ? reject(error) : resolve(id!);
+    };
+
+    const poll = () => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ id: ++messageId, method: "Target.getTargets" }));
+      }
+    };
+    const timer = setTimeout(
+      () => finish(new Error("Timed out waiting for the Stagehand extension service worker")),
+      timeoutMs,
+    );
+    const poller = setInterval(poll, 500);
 
     ws.on("open", poll);
-    ws.on("error", reject);
+    ws.on("error", (error: Error) => finish(error));
+    ws.on("close", () => finish(new Error("CDP socket closed before the Stagehand extension was found")));
     ws.on("message", (buf: Buffer) => {
-      const targets = JSON.parse(buf.toString()).result?.targetInfos;
-      if (!targets) return;
-      const worker = targets.find(
-        (t: { type: string; url: string }) =>
+      let targets: Array<{ type: string; url: string }> | undefined;
+      try {
+        targets = JSON.parse(buf.toString()).result?.targetInfos;
+      } catch {
+        return;
+      }
+      const worker = targets?.find(
+        (t) =>
           t.type === "service_worker" &&
           t.url.startsWith("chrome-extension://") &&
           t.url.includes("service-worker.js"),
       );
-      if (worker) {
-        ws.close();
-        resolve(worker.url.split("/")[2]);
-      } else if (Date.now() > deadline) {
-        ws.close();
-        reject(new Error("Timed out waiting for the Stagehand extension service worker"));
-      } else {
-        setTimeout(poll, 500);
-      }
+      if (worker) finish(null, worker.url.split("/")[2]);
     });
   });
 }
@@ -109,40 +124,44 @@ app.action<CompanyInput, TeamSizeOutput>(
 
     console.log("Kernel browser live view url: ", kernelBrowser.browser_live_view_url);
 
-    const extensionId = await discoverExtensionId(kernelBrowser.cdp_ws_url);
+    // Stagehand only closes browsers it launched, so we close the connection and
+    // delete the Kernel browser ourselves, even if the automation throws.
+    let stagehand: Awaited<ReturnType<typeof Stagehand.create>> | undefined;
+    let browser: Awaited<ReturnType<typeof localBrowser.connect>> | undefined;
+    try {
+      const extensionId = await discoverExtensionId(kernelBrowser.cdp_ws_url);
 
-    const browser = await localBrowser.connect({
-      cdpUrl: kernelBrowser.cdp_ws_url,
-      extensionId,
-    });
-    const stagehand = await Stagehand.create({
-      browser,
-      model: { modelName: MODEL, apiKey: MODEL_API_KEY },
-      logging: { level: "info" },
-    });
+      browser = await localBrowser.connect({
+        cdpUrl: kernelBrowser.cdp_ws_url,
+        extensionId,
+      });
+      stagehand = await Stagehand.create({
+        browser,
+        model: { modelName: MODEL, apiKey: MODEL_API_KEY },
+        logging: { level: "info" },
+      });
 
-    /////////////////////////////////////
-    // Your Stagehand implementation here
-    /////////////////////////////////////
-    const page = await browser.context.activePage();
-    if (!page) throw new Error("No active page in the Kernel browser");
-    await page.goto("https://www.ycombinator.com/companies");
+      /////////////////////////////////////
+      // Your Stagehand implementation here
+      /////////////////////////////////////
+      const page = await browser.context.activePage();
+      if (!page) throw new Error("No active page in the Kernel browser");
+      await page.goto("https://www.ycombinator.com/companies");
 
-    await stagehand.act(`Type in ${company} into the search box`);
-    await stagehand.act("Click on the first search result");
+      await stagehand.act(`Type in ${company} into the search box`);
+      await stagehand.act("Click on the first search result");
 
-    // Extract team size from the YC startup page. Every v4 primitive returns { data }.
-    const { data } = await stagehand.extract(
-      "Extract the team size (number of employees) shown on this Y Combinator company page.",
-      z.object({ teamSize: z.string() }),
-    );
+      // Extract team size from the YC startup page. Every v4 primitive returns { data }.
+      const { data } = await stagehand.extract(
+        "Extract the team size (number of employees) shown on this Y Combinator company page.",
+        z.object({ teamSize: z.string() }),
+      );
 
-    // Stagehand only closes browsers it launched, so close the connection and
-    // delete the Kernel browser ourselves.
-    await stagehand.close();
-    await browser.close();
-    await kernel.browsers.deleteByID(kernelBrowser.session_id);
-
-    return data;
+      return data;
+    } finally {
+      await stagehand?.close();
+      await browser?.close();
+      await kernel.browsers.deleteByID(kernelBrowser.session_id);
+    }
   },
 );

--- a/pkg/templates/typescript/stagehand/index.ts
+++ b/pkg/templates/typescript/stagehand/index.ts
@@ -1,10 +1,15 @@
-import { Stagehand } from "@browserbasehq/stagehand";
-import { Kernel, type KernelContext } from '@onkernel/sdk';
-import { z } from 'zod';
+import { Stagehand, localBrowser, type ModelName } from "@browserbasehq/stagehand";
+import { Kernel, type KernelContext } from "@onkernel/sdk";
+import { createReadStream } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { WebSocket } from "ws";
+// Stagehand v4 uses zod v4 schema types.
+import { z } from "zod";
 
 const kernel = new Kernel();
 
-const app = kernel.app('ts-stagehand');
+const app = kernel.app("ts-stagehand");
 
 interface CompanyInput {
   company: string;
@@ -14,17 +19,74 @@ interface TeamSizeOutput {
   teamSize: string;
 }
 
-// LLM API Keys are set in the environment during `kernel deploy <filename> -e OPENAI_API_KEY=XXX`
+// LLM API Keys are set in the environment during `kernel deploy <filename> -e MODEL_API_KEY=XXX`
 // See https://www.kernel.sh/docs/apps/deploy#environment-variables
+// Defaults to OpenAI. Override MODEL to use another provider (e.g. google/gemini-2.5-flash).
+const MODEL = (process.env.MODEL ?? "openai/gpt-4.1") as ModelName;
+const MODEL_API_KEY = process.env.MODEL_API_KEY ?? process.env.OPENAI_API_KEY;
 
-const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+if (!MODEL_API_KEY) {
+  throw new Error("MODEL_API_KEY (or OPENAI_API_KEY) is not set");
+}
 
-if (!OPENAI_API_KEY) {
-  throw new Error('OPENAI_API_KEY is not set');
+// Stagehand v4 runs as a Chrome extension alongside the browser. When connecting
+// to a remote Kernel browser over CDP we preload that extension at browser
+// creation and hand its runtime id to `localBrowser.connect`.
+const STAGEHAND_EXTENSION_NAME = "stagehand-runtime";
+
+// The extension archive ships inside the installed @browserbasehq/stagehand package.
+const stagehandDist = dirname(fileURLToPath(import.meta.resolve("@browserbasehq/stagehand")));
+const STAGEHAND_EXTENSION_ZIP = join(stagehandDist, "assets/stagehand-extension.zip");
+
+// Upload the Stagehand extension to the project once and reuse it thereafter.
+async function ensureStagehandExtension(): Promise<string> {
+  const existing = await kernel.extensions.list();
+  for (const ext of existing) {
+    if (ext.name === STAGEHAND_EXTENSION_NAME) return STAGEHAND_EXTENSION_NAME;
+  }
+  await kernel.extensions.upload({
+    file: createReadStream(STAGEHAND_EXTENSION_ZIP),
+    name: STAGEHAND_EXTENSION_NAME,
+  });
+  return STAGEHAND_EXTENSION_NAME;
+}
+
+// Chrome assigns the preloaded extension a runtime id. Read it off the extension's
+// service worker target so we can attach Stagehand to it.
+async function discoverExtensionId(cdpUrl: string, timeoutMs = 20_000): Promise<string> {
+  return await new Promise<string>((resolve, reject) => {
+    const ws = new WebSocket(cdpUrl);
+    const deadline = Date.now() + timeoutMs;
+    let messageId = 0;
+
+    const poll = () => ws.send(JSON.stringify({ id: ++messageId, method: "Target.getTargets" }));
+
+    ws.on("open", poll);
+    ws.on("error", reject);
+    ws.on("message", (buf: Buffer) => {
+      const targets = JSON.parse(buf.toString()).result?.targetInfos;
+      if (!targets) return;
+      const worker = targets.find(
+        (t: { type: string; url: string }) =>
+          t.type === "service_worker" &&
+          t.url.startsWith("chrome-extension://") &&
+          t.url.includes("service-worker.js"),
+      );
+      if (worker) {
+        ws.close();
+        resolve(worker.url.split("/")[2]);
+      } else if (Date.now() > deadline) {
+        ws.close();
+        reject(new Error("Timed out waiting for the Stagehand extension service worker"));
+      } else {
+        setTimeout(poll, 500);
+      }
+    });
+  });
 }
 
 app.action<CompanyInput, TeamSizeOutput>(
-  'teamsize-task',
+  "teamsize-task",
   async (ctx: KernelContext, payload?: CompanyInput): Promise<TeamSizeOutput> => {
     // A function that returns the team size of a Y Combinator startup
 
@@ -35,48 +97,52 @@ app.action<CompanyInput, TeamSizeOutput>(
     // Returns:
     //     output: The team size (number of employees) of the startup
 
-    const company = payload?.company || 'kernel';
+    const company = payload?.company || "kernel";
+
+    const extensionName = await ensureStagehandExtension();
 
     const kernelBrowser = await kernel.browsers.create({
       invocation_id: ctx.invocation_id,
       stealth: true,
+      extensions: [{ name: extensionName }],
     });
 
     console.log("Kernel browser live view url: ", kernelBrowser.browser_live_view_url);
 
-    const stagehand = new Stagehand({
-      env: "LOCAL",
-      localBrowserLaunchOptions: {
-        cdpUrl: kernelBrowser.cdp_ws_url,
-      },
-      model: "openai/gpt-4.1",
-      apiKey: OPENAI_API_KEY,
-      verbose: 1,
-      domSettleTimeout: 30_000
+    const extensionId = await discoverExtensionId(kernelBrowser.cdp_ws_url);
+
+    const browser = await localBrowser.connect({
+      cdpUrl: kernelBrowser.cdp_ws_url,
+      extensionId,
     });
-    await stagehand.init();
+    const stagehand = await Stagehand.create({
+      browser,
+      model: { modelName: MODEL, apiKey: MODEL_API_KEY },
+      logging: { level: "info" },
+    });
 
     /////////////////////////////////////
     // Your Stagehand implementation here
     /////////////////////////////////////
-    const page = stagehand.context.pages()[0];
+    const page = await browser.context.activePage();
+    if (!page) throw new Error("No active page in the Kernel browser");
     await page.goto("https://www.ycombinator.com/companies");
 
     await stagehand.act(`Type in ${company} into the search box`);
     await stagehand.act("Click on the first search result");
 
-    // Schema definition
-    const teamSizeSchema = z.object({
-      teamSize: z.string(),
-    });
-    // Extract team size from the YC startup page
-    const output = await stagehand.extract(
+    // Extract team size from the YC startup page. Every v4 primitive returns { data }.
+    const { data } = await stagehand.extract(
       "Extract the team size (number of employees) shown on this Y Combinator company page.",
-      teamSizeSchema
+      z.object({ teamSize: z.string() }),
     );
+
+    // Stagehand only closes browsers it launched, so close the connection and
+    // delete the Kernel browser ourselves.
     await stagehand.close();
+    await browser.close();
     await kernel.browsers.deleteByID(kernelBrowser.session_id);
 
-    return output;
+    return data;
   },
 );

--- a/pkg/templates/typescript/stagehand/index.ts
+++ b/pkg/templates/typescript/stagehand/index.ts
@@ -20,10 +20,10 @@ interface TeamSizeOutput {
 // See https://www.kernel.sh/docs/apps/deploy#environment-variables
 // Defaults to OpenAI. Override MODEL to use another provider (e.g. google/gemini-2.5-flash).
 const MODEL = (process.env.MODEL ?? "openai/gpt-4.1") as ModelName;
-const MODEL_API_KEY = process.env.MODEL_API_KEY ?? process.env.OPENAI_API_KEY;
+const MODEL_API_KEY = process.env.MODEL_API_KEY;
 
 if (!MODEL_API_KEY) {
-  throw new Error("MODEL_API_KEY (or OPENAI_API_KEY) is not set");
+  throw new Error("MODEL_API_KEY is not set");
 }
 
 app.action<CompanyInput, TeamSizeOutput>(

--- a/pkg/templates/typescript/stagehand/package.json
+++ b/pkg/templates/typescript/stagehand/package.json
@@ -4,12 +4,14 @@
   "type": "module",
   "private": true,
   "dependencies": {
-    "@browserbasehq/stagehand": "^3.5.0",
+    "@browserbasehq/stagehand": "^4.0.0",
     "@onkernel/sdk": "^0.23.0",
+    "ws": "^8.18.0",
     "zod": "^4.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.15.17",
+    "@types/ws": "^8.5.12",
     "typescript": "^5.9.3"
   }
 }

--- a/pkg/templates/typescript/stagehand/package.json
+++ b/pkg/templates/typescript/stagehand/package.json
@@ -6,12 +6,10 @@
   "dependencies": {
     "@browserbasehq/stagehand": "^4.0.0",
     "@onkernel/sdk": "^0.23.0",
-    "ws": "^8.18.0",
     "zod": "^4.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.15.17",
-    "@types/ws": "^8.5.12",
     "typescript": "^5.9.3"
   }
 }

--- a/pkg/templates/typescript/stagehand/pnpm-lock.yaml
+++ b/pkg/templates/typescript/stagehand/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@onkernel/sdk':
         specifier: ^0.23.0
         version: 0.23.0
-      ws:
-        specifier: ^8.18.0
-        version: 8.21.3
       zod:
         specifier: ^4.2.0
         version: 4.4.3
@@ -24,9 +21,6 @@ importers:
       '@types/node':
         specifier: ^22.15.17
         version: 22.20.1
-      '@types/ws':
-        specifier: ^8.5.12
-        version: 8.18.1
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -65,9 +59,6 @@ packages:
 
   '@types/node@22.20.1':
     resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
-
-  '@types/ws@8.18.1':
-    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -243,18 +234,6 @@ packages:
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
-  ws@8.21.3:
-    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -306,10 +285,6 @@ snapshots:
   '@types/node@22.20.1':
     dependencies:
       undici-types: 6.21.0
-
-  '@types/ws@8.18.1':
-    dependencies:
-      '@types/node': 22.20.1
 
   abort-controller@3.0.0:
     dependencies:
@@ -468,7 +443,5 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-
-  ws@8.21.3: {}
 
   zod@4.4.3: {}

--- a/pkg/templates/typescript/stagehand/pnpm-lock.yaml
+++ b/pkg/templates/typescript/stagehand/pnpm-lock.yaml
@@ -9,255 +9,53 @@ importers:
   .:
     dependencies:
       '@browserbasehq/stagehand':
-        specifier: ^3.5.0
-        version: 3.5.0(@cfworker/json-schema@4.1.1)(patchright-core@1.57.0)(playwright-core@1.57.0)(zod@4.2.0)
+        specifier: ^4.0.0
+        version: 4.0.0
       '@onkernel/sdk':
         specifier: ^0.23.0
         version: 0.23.0
+      ws:
+        specifier: ^8.18.0
+        version: 8.21.3
       zod:
         specifier: ^4.2.0
-        version: 4.2.0
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: ^22.15.17
-        version: 22.19.3
+        version: 22.20.1
+      '@types/ws':
+        specifier: ^8.5.12
+        version: 8.18.1
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
 
 packages:
 
-  '@ai-sdk/amazon-bedrock@3.0.100':
-    resolution: {integrity: sha512-axG638+xoSlhURHh5usIFLN8FhObEe8qTbfcvljaoCrzijrRxlgX71ePdD/jyM58Y6l3S2WHDgft56PColgDHA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
+  '@browserbasehq/sdk@2.16.0':
+    resolution: {integrity: sha512-mPAuLRU9jWR7o0KJi9+gQnOBDUSIkoKbbFv4HjrA+80qWVcFacrNPlZmf4mguQnfZ0oP2t5c3ws6yuFyAX9vpA==}
 
-  '@ai-sdk/anthropic@2.0.80':
-    resolution: {integrity: sha512-7HPgFv91YFFYyZapM/Vy3tRbBq/hL44omh0vz/WikiU7fJFxdOjCeg6Nb089lxM7+qBe7blZsoSRJ7gfAkEo1w==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/azure@2.0.109':
-    resolution: {integrity: sha512-0Cd/YzLkF12v8NEyowNdZ3WLGXzdaQeBd4I6EreuQuCnSgO+SwhsS7RbnVB4/FVISgoctSf8+/ojkO+gAC47Sg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/cerebras@1.0.44':
-    resolution: {integrity: sha512-2w7+jq0bWEF6McgWPb2gjaEx1TpqdUq4eyX/gPLTp7HzfDZKEVmmVXRvnKvjzBP/VH7xW4OT5jhTpTPTfYNYYQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/deepseek@1.0.41':
-    resolution: {integrity: sha512-7L2Do5wk0xRe0Ox8CVRF9B5b5SPemZP16ZbyBUAlNtO16EMFLSX8LXGeQREZ2SOQ4pC95BwSXThcTkt1JbFNlA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/gateway@2.0.97':
-    resolution: {integrity: sha512-8lM9IuiUcYNw9aYKKsD9Rwr7tfbBxIgsCNlktGBGS7IQHe7bLbK0AZzQKKVWz3JxJn/nhVbGtiFNt3fUnHahvQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/google-vertex@3.0.140':
-    resolution: {integrity: sha512-didlWnjTRvTM+yEoHNi/I+WnwlxpWcLMZtylFodVzuUOLhmQltoP46RgKG5hfXsGYwbnfBJbKcf6rvhOzYHSWQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/google@2.0.74':
-    resolution: {integrity: sha512-Lhw1742RXc+4pRIvqVXa0jdl5+qdpmw8lj0lm6OchUg9rVGHzymlaxe7CDiYX5U2af4jbjKeTY22LDi3bIycgQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/groq@2.0.40':
-    resolution: {integrity: sha512-1EL8D1tyjOKjCFUt8XspDoA6zxDcalMsLR2O56ji8QklWsAPaf4TuMJAvf5x5KDrkuJaSAjk94KvPH5hOX+VNQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/mistral@2.0.33':
-    resolution: {integrity: sha512-oBR9nJQ8TRFU0JIIXF+0cFTo8VVEreA1V8AMD3c77BJj/1NUSBLrhyqAbX9k7YAtztvZHUdFcm3+vK8KIx0sUQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/openai-compatible@1.0.39':
-    resolution: {integrity: sha512-001hdQPPXxYBWrz5d+eAmBVYmwzsB+guIey1DFXi1ZEE5H3j7fRrhPpX55MdM9Fle2DS7WZ8b3qkumCIWE92YQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/openai@2.0.106':
-    resolution: {integrity: sha512-EFC0rpo1wfe4HIz5KZCE72edP2J7fOeR7wPXzjCDljaTRB1wectKDIKRLowpU4F0mbcJ+XScAsoYNPK/Z20aVQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/perplexity@2.0.30':
-    resolution: {integrity: sha512-ymXWoItR4tRCIQlJcpn0zk4jBUU+j4SDnliz/z1f5U6rWxNY1ttxFCk4uZ+6Zt9e3VjQTpA9FK6cOJt18JRrKQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider-utils@3.0.25':
-    resolution: {integrity: sha512-CvsRu+32Y8a167s+lrIBtsybvgTHp8j9y+6BeTvLeoW3Q+okw/b4CnNUFOLIXsRaKHQKAH+IHNJPYWywfpw0LA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider@2.0.3':
-    resolution: {integrity: sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==}
-    engines: {node: '>=18'}
-
-  '@ai-sdk/togetherai@1.0.42':
-    resolution: {integrity: sha512-V9reHPfWeaIt6fu03lVbjZDuxfdplS5jdmzVchVBeUug9VqIK+9KQELcPvdWKdxf+ov+sCoShN/O6dYfPPD5Ng==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/xai@2.0.73':
-    resolution: {integrity: sha512-U+/rdtqgDcloNSX7TIdRjYQooVydYdauQvLSP74oQcnE5N0/DD81yi+RvQXYYq47dDIn2H4exgr7XkBm4x1yDw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@anthropic-ai/sdk@0.39.0':
-    resolution: {integrity: sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==}
-
-  '@aws-crypto/crc32@5.2.0':
-    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
-    engines: {node: '>=16.0.0'}
-
-  '@aws-crypto/util@5.2.0':
-    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
-
-  '@aws-sdk/types@3.973.12':
-    resolution: {integrity: sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==}
-    engines: {node: '>=20.0.0'}
-
-  '@browserbasehq/sdk@2.14.0':
-    resolution: {integrity: sha512-DqVfjlgt74vPWfWiCp4VPtiMNJxg2yBZwio2uOfnpV1aJM0OWZR4AJrt/4df+xgQQ/guRpds5do41ycrDaYt3w==}
-
-  '@browserbasehq/stagehand@3.5.0':
-    resolution: {integrity: sha512-nmKmi37keeZ8naUTJ4l6nfR8sTCDc5gUIn+fKSzMH8Xy4IW/sFNaA14Gl3OQbUWpthr977yGCBj556WSWONg0w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    peerDependencies:
-      patchright-core: ^1.55.2
-      playwright-core: ^1.55.1
-      puppeteer-core: ^24.43.0
-      zod: ^3.25.76 || ^4.2.0
-    peerDependenciesMeta:
-      patchright-core:
-        optional: true
-      playwright-core:
-        optional: true
-      puppeteer-core:
-        optional: true
-
-  '@cfworker/json-schema@4.1.1':
-    resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
-
-  '@google/genai@1.52.0':
-    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.25.2
-    peerDependenciesMeta:
-      '@modelcontextprotocol/sdk':
-        optional: true
-
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
-    peerDependencies:
-      hono: ^4
-
-  '@modelcontextprotocol/sdk@1.29.0':
-    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
-    peerDependenciesMeta:
-      '@cfworker/json-schema':
-        optional: true
+  '@browserbasehq/stagehand@4.0.0':
+    resolution: {integrity: sha512-AUmK6TYqsXCG63d8Jh5bxcpef3KfGaGBCT8Z6qOCLFKLafwjT3VJXFKAWTxLRYqkMWeLH3qK7qFsXHONPF2JWg==}
+    engines: {node: '>=22.18.0'}
 
   '@onkernel/sdk@0.23.0':
     resolution: {integrity: sha512-P/ez6HU8sO2QvqWATkvC+Wdv+fgto4KfBCHLl2T6EUpoU3LhgOZ/sJP2ZRf/vh5Vh7QR2Vf05RgMaFcIGBGD9Q==}
 
-  '@opentelemetry/api@1.9.0':
-    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
 
-  '@pinojs/redact@0.4.0':
-    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+  '@opentelemetry/core@2.9.0':
+    resolution: {integrity: sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@protobufjs/aspromise@1.1.2':
-    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
-
-  '@protobufjs/base64@1.1.2':
-    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
-
-  '@protobufjs/codegen@2.0.5':
-    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
-
-  '@protobufjs/eventemitter@1.1.1':
-    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
-
-  '@protobufjs/fetch@1.1.1':
-    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
-
-  '@protobufjs/float@1.0.2':
-    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
-
-  '@protobufjs/inquire@1.1.2':
-    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
-
-  '@protobufjs/path@1.1.2':
-    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
-
-  '@protobufjs/pool@1.1.0':
-    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
-
-  '@protobufjs/utf8@1.1.1':
-    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
-
-  '@smithy/core@3.24.6':
-    resolution: {integrity: sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-codec@4.3.6':
-    resolution: {integrity: sha512-Ussyv240JxwQP8AmkYdm26wGP/1I8QmIv0ZosgDJDlSzD73FEdj1BOpXMc06VrxX5KxTKhadFNomT2SWutUnpg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/is-array-buffer@2.2.0':
-    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/types@4.14.3':
-    resolution: {integrity: sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-buffer-from@2.2.0':
-    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/util-utf8@2.3.0':
-    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/util-utf8@4.3.6':
-    resolution: {integrity: sha512-tAa4sePYB7mlJzdYbdBqdv37KwFKWixmM/r3ihcI0HFOVjf+a5oGvtcLXcGm4S1bY4DFsLAIOHgjubtp+oRufw==}
-    engines: {node: '>=18.0.0'}
-
-  '@standard-schema/spec@1.1.0':
-    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
 
   '@types/node-fetch@2.6.13':
     resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
@@ -265,86 +63,25 @@ packages:
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
-  '@types/node@22.19.3':
-    resolution: {integrity: sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==}
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
 
-  '@types/retry@0.12.0':
-    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
-
-  '@vercel/oidc@3.1.0':
-    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
-    engines: {node: '>= 20'}
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
-  accepts@2.0.0:
-    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
-    engines: {node: '>= 0.6'}
-
-  agent-base@7.1.4:
-    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
-    engines: {node: '>= 14'}
-
   agentkeepalive@4.6.0:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
 
-  ai@5.0.196:
-    resolution: {integrity: sha512-JaljZ1/UagJ1oJp8CcMDxXoE2E2pv4Q/hETkhcD8aE15pbnO7KhEeIqLgsQEizJjc5AquS7matl6GfnDQUDUpA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  ajv-formats@3.0.1:
-    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
-
-  ajv@8.20.0:
-    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
-
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  atomic-sleep@1.0.0:
-    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
-    engines: {node: '>=8.0.0'}
-
-  aws4fetch@1.0.20:
-    resolution: {integrity: sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==}
-
-  base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
-  bignumber.js@9.3.1:
-    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
-
-  body-parser@2.2.2:
-    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
-    engines: {node: '>=18'}
-
-  buffer-equal-constant-time@1.0.1:
-    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
-
-  bufferutil@4.1.0:
-    resolution: {integrity: sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==}
-    engines: {node: '>=6.14.2'}
-
-  bytes@3.1.2:
-    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
-    engines: {node: '>= 0.8'}
-
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
-    engines: {node: '>= 0.4'}
-
-  call-bound@1.0.4:
-    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   chrome-launcher@1.2.1:
@@ -352,47 +89,9 @@ packages:
     engines: {node: '>=12.13.0'}
     hasBin: true
 
-  colorette@2.0.20:
-    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
-
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
-
-  content-disposition@1.1.0:
-    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
-    engines: {node: '>=18'}
-
-  content-type@1.0.5:
-    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
-    engines: {node: '>= 0.6'}
-
-  content-type@2.0.0:
-    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
-    engines: {node: '>=18'}
-
-  cookie-signature@1.2.2:
-    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
-    engines: {node: '>=6.6.0'}
-
-  cookie@0.7.2:
-    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
-    engines: {node: '>= 0.6'}
-
-  cors@2.8.6:
-    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
-    engines: {node: '>= 0.10'}
-
-  cross-spawn@7.0.6:
-    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
-    engines: {node: '>= 8'}
-
-  data-uri-to-buffer@4.0.1:
-    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
-    engines: {node: '>= 12'}
-
-  dateformat@4.6.3:
-    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -407,29 +106,9 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
-  depd@2.0.0:
-    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
-    engines: {node: '>= 0.8'}
-
-  devtools-protocol@0.0.1464554:
-    resolution: {integrity: sha512-CAoP3lYfwAGQTaAXYvA6JZR0fjGUb7qec1qf4mToyoH2TZgUFeIqYcjh6f9jNuhHfuZiEdH+PONHYrLhRQX6aw==}
-
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
-
-  ecdsa-sig-formatter@1.0.11:
-    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
-
-  ee-first@1.1.1:
-    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
-
-  encodeurl@2.0.0:
-    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
-    engines: {node: '>= 0.8'}
-
-  end-of-stream@1.4.5:
-    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -447,98 +126,27 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
-  escape-html@1.0.3:
-    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
-
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
-
-  etag@1.8.1:
-    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
-    engines: {node: '>= 0.6'}
 
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
 
-  eventsource-parser@3.1.0:
-    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
-    engines: {node: '>=18.0.0'}
-
-  eventsource@3.0.7:
-    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
-    engines: {node: '>=18.0.0'}
-
-  express-rate-limit@8.5.2:
-    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
-    engines: {node: '>= 16'}
-    peerDependencies:
-      express: '>= 4.11'
-
-  express@5.2.1:
-    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
-    engines: {node: '>= 18'}
-
-  extend@3.0.2:
-    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
-
-  fast-copy@4.0.3:
-    resolution: {integrity: sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==}
-
-  fast-deep-equal@3.1.3:
-    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-
-  fast-safe-stringify@2.1.1:
-    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
-
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
-
-  fetch-blob@3.2.0:
-    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
-    engines: {node: ^12.20 || >= 14.13}
-
-  fetch-cookie@3.2.0:
-    resolution: {integrity: sha512-n61pQIxP25C6DRhcJxn7BDzgHP/+S56Urowb5WFxtcRMpU6drqXD90xjyAsVQYsNSNNVbaCcYY1DuHsdkZLuiA==}
-
-  finalhandler@2.1.1:
-    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
-    engines: {node: '>= 18.0.0'}
-
   form-data-encoder@1.7.2:
     resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   formdata-node@4.4.1:
     resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
     engines: {node: '>= 12.20'}
 
-  formdata-polyfill@4.0.10:
-    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
-    engines: {node: '>=12.20.0'}
-
-  forwarded@0.2.0:
-    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
-    engines: {node: '>= 0.6'}
-
-  fresh@2.0.0:
-    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
-    engines: {node: '>= 0.8'}
-
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-
-  gaxios@7.1.5:
-    resolution: {integrity: sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==}
-    engines: {node: '>=18'}
-
-  gcp-metadata@8.1.2:
-    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
-    engines: {node: '>=18'}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -547,14 +155,6 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
-
-  google-auth-library@10.7.0:
-    resolution: {integrity: sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==}
-    engines: {node: '>=18'}
-
-  google-logging-utils@1.1.3:
-    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
-    engines: {node: '>=14'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -572,84 +172,20 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  help-me@5.0.0:
-    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
-
-  hono@4.12.25:
-    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
-    engines: {node: '>=16.9.0'}
-
-  http-errors@2.0.1:
-    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
-    engines: {node: '>= 0.8'}
-
-  https-proxy-agent@7.0.6:
-    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
-    engines: {node: '>= 14'}
-
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
-
-  iconv-lite@0.7.2:
-    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
-    engines: {node: '>=0.10.0'}
-
-  inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
-    engines: {node: '>= 12'}
-
-  ipaddr.js@1.9.1:
-    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
-    engines: {node: '>= 0.10'}
 
   is-docker@2.2.1:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
     engines: {node: '>=8'}
     hasBin: true
 
-  is-promise@4.0.0:
-    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
-
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
 
-  isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  jose@6.2.3:
-    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
-
-  joycon@3.1.1:
-    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
-    engines: {node: '>=10'}
-
-  json-bigint@1.0.0:
-    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
-
-  json-schema-traverse@1.0.0:
-    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
-
-  json-schema-typed@8.0.2:
-    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
-
-  json-schema@0.4.0:
-    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
-
-  jwa@2.0.1:
-    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
-
-  jws@4.0.1:
-    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
-
   lighthouse-logger@2.0.2:
     resolution: {integrity: sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg==}
-
-  long@5.3.2:
-    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   marky@1.3.0:
     resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
@@ -658,39 +194,16 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  media-typer@1.1.0:
-    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
-    engines: {node: '>= 0.8'}
-
-  merge-descriptors@2.0.0:
-    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
-    engines: {node: '>=18'}
-
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
-
-  mime-db@1.54.0:
-    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
 
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
-  mime-types@3.0.2:
-    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
-    engines: {node: '>=18'}
-
-  minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
-  negotiator@1.0.0:
-    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
-    engines: {node: '>= 0.6'}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -706,235 +219,8 @@ packages:
       encoding:
         optional: true
 
-  node-fetch@3.3.2:
-    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  node-gyp-build@4.8.4:
-    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
-    hasBin: true
-
-  object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
-
-  object-inspect@1.13.4:
-    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
-    engines: {node: '>= 0.4'}
-
-  ollama-ai-provider-v2@1.5.5:
-    resolution: {integrity: sha512-1YwTFdPjhPNHny/DrOHO+s8oVGGIE5Jib61/KnnjPRNWQhVVimrJJdaAX3e6nNRRDXrY5zbb9cfm2+yVvgsrqw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^4.0.16
-
-  on-exit-leak-free@2.1.2:
-    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
-    engines: {node: '>=14.0.0'}
-
-  on-finished@2.4.1:
-    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
-    engines: {node: '>= 0.8'}
-
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
-
-  openai@4.104.0:
-    resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
-    hasBin: true
-    peerDependencies:
-      ws: ^8.18.0
-      zod: ^3.23.8
-    peerDependenciesMeta:
-      ws:
-        optional: true
-      zod:
-        optional: true
-
-  p-retry@4.6.2:
-    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
-    engines: {node: '>=8'}
-
-  parseurl@1.3.3:
-    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
-    engines: {node: '>= 0.8'}
-
-  patchright-core@1.57.0:
-    resolution: {integrity: sha512-um/9Wue7IFAa9UDLacjNgDn62ub5GJe1b1qouvYpELIF9rsFVMNhRo/rRXYajupLwp5xKJ0sSjOV6sw8/HarBQ==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
-    engines: {node: '>=8'}
-
-  path-to-regexp@8.4.2:
-    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
-
-  pino-abstract-transport@2.0.0:
-    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
-
-  pino-abstract-transport@3.0.0:
-    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
-
-  pino-pretty@13.1.3:
-    resolution: {integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==}
-    hasBin: true
-
-  pino-std-serializers@7.1.0:
-    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
-
-  pino@9.14.0:
-    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
-    hasBin: true
-
-  pkce-challenge@5.0.1:
-    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
-    engines: {node: '>=16.20.0'}
-
-  playwright-core@1.57.0:
-    resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  process-warning@5.0.0:
-    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
-
-  protobufjs@7.6.2:
-    resolution: {integrity: sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==}
-    engines: {node: '>=12.0.0'}
-
-  proxy-addr@2.0.7:
-    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
-    engines: {node: '>= 0.10'}
-
-  pump@3.0.4:
-    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
-
-  qs@6.15.2:
-    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
-    engines: {node: '>=0.6'}
-
-  quick-format-unescaped@4.0.4:
-    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
-
-  range-parser@1.2.1:
-    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
-    engines: {node: '>= 0.6'}
-
-  raw-body@3.0.2:
-    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
-    engines: {node: '>= 0.10'}
-
-  real-require@0.2.0:
-    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
-    engines: {node: '>= 12.13.0'}
-
-  require-from-string@2.0.2:
-    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
-    engines: {node: '>=0.10.0'}
-
-  retry@0.13.1:
-    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
-    engines: {node: '>= 4'}
-
-  router@2.2.0:
-    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
-    engines: {node: '>= 18'}
-
-  safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-
-  safe-stable-stringify@2.5.0:
-    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
-    engines: {node: '>=10'}
-
-  safer-buffer@2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-
-  secure-json-parse@4.1.0:
-    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
-
-  send@1.2.1:
-    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
-    engines: {node: '>= 18'}
-
-  serve-static@2.2.1:
-    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
-    engines: {node: '>= 18'}
-
-  set-cookie-parser@2.7.2:
-    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
-
-  setprototypeof@1.2.0:
-    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
-
-  shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
-
-  shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
-
-  side-channel-list@1.0.1:
-    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
-    engines: {node: '>= 0.4'}
-
-  side-channel-map@1.0.1:
-    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
-    engines: {node: '>= 0.4'}
-
-  side-channel-weakmap@1.0.2:
-    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
-    engines: {node: '>= 0.4'}
-
-  side-channel@1.1.1:
-    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
-    engines: {node: '>= 0.4'}
-
-  sonic-boom@4.2.1:
-    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
-
-  split2@4.2.0:
-    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
-    engines: {node: '>= 10.x'}
-
-  statuses@2.0.2:
-    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
-    engines: {node: '>= 0.8'}
-
-  strip-json-comments@5.0.3:
-    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
-    engines: {node: '>=14.16'}
-
-  thread-stream@3.2.0:
-    resolution: {integrity: sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==}
-
-  tldts-core@7.4.2:
-    resolution: {integrity: sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==}
-
-  tldts@7.4.2:
-    resolution: {integrity: sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==}
-    hasBin: true
-
-  toidentifier@1.0.1:
-    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
-    engines: {node: '>=0.6'}
-
-  tough-cookie@6.0.1:
-    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
-    engines: {node: '>=16'}
-
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
-  tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
-
-  type-is@2.1.0:
-    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
-    engines: {node: '>= 18'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -947,22 +233,6 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  unpipe@1.0.0:
-    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
-    engines: {node: '>= 0.8'}
-
-  uuid@11.1.1:
-    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
-    hasBin: true
-
-  vary@1.1.2:
-    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
-    engines: {node: '>= 0.8'}
-
-  web-streams-polyfill@3.3.3:
-    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
-    engines: {node: '>= 8'}
-
   web-streams-polyfill@4.0.0-beta.3:
     resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
     engines: {node: '>= 14'}
@@ -973,16 +243,8 @@ packages:
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
-  which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
-    hasBin: true
-
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-
-  ws@8.21.0:
-    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -993,147 +255,12 @@ packages:
       utf-8-validate:
         optional: true
 
-  zod-to-json-schema@3.25.2:
-    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
-    peerDependencies:
-      zod: ^3.25.28 || ^4
-
-  zod@4.2.0:
-    resolution: {integrity: sha512-Bd5fw9wlIhtqCCxotZgdTOMwGm1a0u75wARVEY9HMs1X17trvA/lMi4+MGK5EUfYkXVTbX8UDiDKW4OgzHVUZw==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
-  '@ai-sdk/amazon-bedrock@3.0.100(zod@4.2.0)':
-    dependencies:
-      '@ai-sdk/anthropic': 2.0.80(zod@4.2.0)
-      '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.25(zod@4.2.0)
-      '@smithy/eventstream-codec': 4.3.6
-      '@smithy/util-utf8': 4.3.6
-      aws4fetch: 1.0.20
-      zod: 4.2.0
-    optional: true
-
-  '@ai-sdk/anthropic@2.0.80(zod@4.2.0)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.25(zod@4.2.0)
-      zod: 4.2.0
-    optional: true
-
-  '@ai-sdk/azure@2.0.109(zod@4.2.0)':
-    dependencies:
-      '@ai-sdk/openai': 2.0.106(zod@4.2.0)
-      '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.25(zod@4.2.0)
-      zod: 4.2.0
-    optional: true
-
-  '@ai-sdk/cerebras@1.0.44(zod@4.2.0)':
-    dependencies:
-      '@ai-sdk/openai-compatible': 1.0.39(zod@4.2.0)
-      '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.25(zod@4.2.0)
-      zod: 4.2.0
-    optional: true
-
-  '@ai-sdk/deepseek@1.0.41(zod@4.2.0)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.25(zod@4.2.0)
-      zod: 4.2.0
-    optional: true
-
-  '@ai-sdk/gateway@2.0.97(zod@4.2.0)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.25(zod@4.2.0)
-      '@vercel/oidc': 3.1.0
-      zod: 4.2.0
-
-  '@ai-sdk/google-vertex@3.0.140(zod@4.2.0)':
-    dependencies:
-      '@ai-sdk/anthropic': 2.0.80(zod@4.2.0)
-      '@ai-sdk/google': 2.0.74(zod@4.2.0)
-      '@ai-sdk/openai-compatible': 1.0.39(zod@4.2.0)
-      '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.25(zod@4.2.0)
-      google-auth-library: 10.7.0
-      zod: 4.2.0
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  '@ai-sdk/google@2.0.74(zod@4.2.0)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.25(zod@4.2.0)
-      zod: 4.2.0
-    optional: true
-
-  '@ai-sdk/groq@2.0.40(zod@4.2.0)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.25(zod@4.2.0)
-      zod: 4.2.0
-    optional: true
-
-  '@ai-sdk/mistral@2.0.33(zod@4.2.0)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.25(zod@4.2.0)
-      zod: 4.2.0
-    optional: true
-
-  '@ai-sdk/openai-compatible@1.0.39(zod@4.2.0)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.25(zod@4.2.0)
-      zod: 4.2.0
-    optional: true
-
-  '@ai-sdk/openai@2.0.106(zod@4.2.0)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.25(zod@4.2.0)
-      zod: 4.2.0
-    optional: true
-
-  '@ai-sdk/perplexity@2.0.30(zod@4.2.0)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.25(zod@4.2.0)
-      zod: 4.2.0
-    optional: true
-
-  '@ai-sdk/provider-utils@3.0.25(zod@4.2.0)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.3
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.1.0
-      zod: 4.2.0
-
-  '@ai-sdk/provider@2.0.3':
-    dependencies:
-      json-schema: 0.4.0
-
-  '@ai-sdk/togetherai@1.0.42(zod@4.2.0)':
-    dependencies:
-      '@ai-sdk/openai-compatible': 1.0.39(zod@4.2.0)
-      '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.25(zod@4.2.0)
-      zod: 4.2.0
-    optional: true
-
-  '@ai-sdk/xai@2.0.73(zod@4.2.0)':
-    dependencies:
-      '@ai-sdk/openai-compatible': 1.0.39(zod@4.2.0)
-      '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.25(zod@4.2.0)
-      zod: 4.2.0
-    optional: true
-
-  '@anthropic-ai/sdk@0.39.0':
+  '@browserbasehq/sdk@2.16.0':
     dependencies:
       '@types/node': 18.19.130
       '@types/node-fetch': 2.6.13
@@ -1145,330 +272,72 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@aws-crypto/crc32@5.2.0':
+  '@browserbasehq/stagehand@4.0.0':
     dependencies:
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.12
-      tslib: 2.8.1
-    optional: true
-
-  '@aws-crypto/util@5.2.0':
-    dependencies:
-      '@aws-sdk/types': 3.973.12
-      '@smithy/util-utf8': 2.3.0
-      tslib: 2.8.1
-    optional: true
-
-  '@aws-sdk/types@3.973.12':
-    dependencies:
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-    optional: true
-
-  '@browserbasehq/sdk@2.14.0':
-    dependencies:
-      '@types/node': 18.19.130
-      '@types/node-fetch': 2.6.13
-      abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
-
-  '@browserbasehq/stagehand@3.5.0(@cfworker/json-schema@4.1.1)(patchright-core@1.57.0)(playwright-core@1.57.0)(zod@4.2.0)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.3
-      '@anthropic-ai/sdk': 0.39.0
-      '@browserbasehq/sdk': 2.14.0
-      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.2.0))(bufferutil@4.1.0)
-      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.2.0)
-      ai: 5.0.196(zod@4.2.0)
-      devtools-protocol: 0.0.1464554
-      fetch-cookie: 3.2.0
-      openai: 4.104.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.2.0)
-      pino: 9.14.0
-      pino-pretty: 13.1.3
-      uuid: 11.1.1
-      ws: 8.21.0(bufferutil@4.1.0)
-      zod: 4.2.0
-      zod-to-json-schema: 3.25.2(zod@4.2.0)
-    optionalDependencies:
-      '@ai-sdk/amazon-bedrock': 3.0.100(zod@4.2.0)
-      '@ai-sdk/anthropic': 2.0.80(zod@4.2.0)
-      '@ai-sdk/azure': 2.0.109(zod@4.2.0)
-      '@ai-sdk/cerebras': 1.0.44(zod@4.2.0)
-      '@ai-sdk/deepseek': 1.0.41(zod@4.2.0)
-      '@ai-sdk/google': 2.0.74(zod@4.2.0)
-      '@ai-sdk/google-vertex': 3.0.140(zod@4.2.0)
-      '@ai-sdk/groq': 2.0.40(zod@4.2.0)
-      '@ai-sdk/mistral': 2.0.33(zod@4.2.0)
-      '@ai-sdk/openai': 2.0.106(zod@4.2.0)
-      '@ai-sdk/perplexity': 2.0.30(zod@4.2.0)
-      '@ai-sdk/togetherai': 1.0.42(zod@4.2.0)
-      '@ai-sdk/xai': 2.0.73(zod@4.2.0)
-      bufferutil: 4.1.0
+      '@browserbasehq/sdk': 2.16.0
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       chrome-launcher: 1.2.1
-      ollama-ai-provider-v2: 1.5.5(zod@4.2.0)
-      patchright-core: 1.57.0
-      playwright-core: 1.57.0
+      zod: 4.4.3
     transitivePeerDependencies:
-      - '@cfworker/json-schema'
       - encoding
-      - supports-color
-      - utf-8-validate
-
-  '@cfworker/json-schema@4.1.1':
-    optional: true
-
-  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.2.0))(bufferutil@4.1.0)':
-    dependencies:
-      google-auth-library: 10.7.0
-      p-retry: 4.6.2
-      protobufjs: 7.6.2
-      ws: 8.21.0(bufferutil@4.1.0)
-    optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.2.0)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@hono/node-server@1.19.14(hono@4.12.25)':
-    dependencies:
-      hono: 4.12.25
-
-  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.2.0)':
-    dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.25)
-      ajv: 8.20.0
-      ajv-formats: 3.0.1(ajv@8.20.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.1.0
-      express: 5.2.1
-      express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.25
-      jose: 6.2.3
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 4.2.0
-      zod-to-json-schema: 3.25.2(zod@4.2.0)
-    optionalDependencies:
-      '@cfworker/json-schema': 4.1.1
-    transitivePeerDependencies:
       - supports-color
 
   '@onkernel/sdk@0.23.0': {}
 
-  '@opentelemetry/api@1.9.0': {}
+  '@opentelemetry/api@1.9.1': {}
 
-  '@pinojs/redact@0.4.0': {}
-
-  '@protobufjs/aspromise@1.1.2': {}
-
-  '@protobufjs/base64@1.1.2': {}
-
-  '@protobufjs/codegen@2.0.5': {}
-
-  '@protobufjs/eventemitter@1.1.1': {}
-
-  '@protobufjs/fetch@1.1.1':
+  '@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@protobufjs/aspromise': 1.1.2
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.43.0
 
-  '@protobufjs/float@1.0.2': {}
-
-  '@protobufjs/inquire@1.1.2': {}
-
-  '@protobufjs/path@1.1.2': {}
-
-  '@protobufjs/pool@1.1.0': {}
-
-  '@protobufjs/utf8@1.1.1': {}
-
-  '@smithy/core@3.24.6':
-    dependencies:
-      '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-    optional: true
-
-  '@smithy/eventstream-codec@4.3.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-    optional: true
-
-  '@smithy/is-array-buffer@2.2.0':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@smithy/types@4.14.3':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@smithy/util-buffer-from@2.2.0':
-    dependencies:
-      '@smithy/is-array-buffer': 2.2.0
-      tslib: 2.8.1
-    optional: true
-
-  '@smithy/util-utf8@2.3.0':
-    dependencies:
-      '@smithy/util-buffer-from': 2.2.0
-      tslib: 2.8.1
-    optional: true
-
-  '@smithy/util-utf8@4.3.6':
-    dependencies:
-      '@smithy/core': 3.24.6
-      tslib: 2.8.1
-    optional: true
-
-  '@standard-schema/spec@1.1.0': {}
+  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@types/node-fetch@2.6.13':
     dependencies:
-      '@types/node': 22.19.3
-      form-data: 4.0.5
+      '@types/node': 22.20.1
+      form-data: 4.0.6
 
   '@types/node@18.19.130':
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@22.19.3':
+  '@types/node@22.20.1':
     dependencies:
       undici-types: 6.21.0
 
-  '@types/retry@0.12.0': {}
-
-  '@vercel/oidc@3.1.0': {}
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.20.1
 
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
 
-  accepts@2.0.0:
-    dependencies:
-      mime-types: 3.0.2
-      negotiator: 1.0.0
-
-  agent-base@7.1.4: {}
-
   agentkeepalive@4.6.0:
     dependencies:
       humanize-ms: 1.2.1
 
-  ai@5.0.196(zod@4.2.0):
-    dependencies:
-      '@ai-sdk/gateway': 2.0.97(zod@4.2.0)
-      '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.25(zod@4.2.0)
-      '@opentelemetry/api': 1.9.0
-      zod: 4.2.0
-
-  ajv-formats@3.0.1(ajv@8.20.0):
-    optionalDependencies:
-      ajv: 8.20.0
-
-  ajv@8.20.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
-
   asynckit@0.4.0: {}
-
-  atomic-sleep@1.0.0: {}
-
-  aws4fetch@1.0.20:
-    optional: true
-
-  base64-js@1.5.1: {}
-
-  bignumber.js@9.3.1: {}
-
-  body-parser@2.2.2:
-    dependencies:
-      bytes: 3.1.2
-      content-type: 1.0.5
-      debug: 4.4.3
-      http-errors: 2.0.1
-      iconv-lite: 0.7.2
-      on-finished: 2.4.1
-      qs: 6.15.2
-      raw-body: 3.0.2
-      type-is: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-
-  buffer-equal-constant-time@1.0.1: {}
-
-  bufferutil@4.1.0:
-    dependencies:
-      node-gyp-build: 4.8.4
-    optional: true
-
-  bytes@3.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
-  call-bound@1.0.4:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      get-intrinsic: 1.3.0
-
   chrome-launcher@1.2.1:
     dependencies:
-      '@types/node': 22.19.3
+      '@types/node': 22.20.1
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 2.0.2
     transitivePeerDependencies:
       - supports-color
-    optional: true
-
-  colorette@2.0.20: {}
 
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
-
-  content-disposition@1.1.0: {}
-
-  content-type@1.0.5: {}
-
-  content-type@2.0.0: {}
-
-  cookie-signature@1.2.2: {}
-
-  cookie@0.7.2: {}
-
-  cors@2.8.6:
-    dependencies:
-      object-assign: 4.1.1
-      vary: 1.1.2
-
-  cross-spawn@7.0.6:
-    dependencies:
-      path-key: 3.1.1
-      shebang-command: 2.0.0
-      which: 2.0.2
-
-  data-uri-to-buffer@4.0.1: {}
-
-  dateformat@4.6.3: {}
 
   debug@4.4.3:
     dependencies:
@@ -1476,27 +345,11 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
-  depd@2.0.0: {}
-
-  devtools-protocol@0.0.1464554: {}
-
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
-
-  ecdsa-sig-formatter@1.0.11:
-    dependencies:
-      safe-buffer: 5.2.1
-
-  ee-first@1.1.1: {}
-
-  encodeurl@2.0.0: {}
-
-  end-of-stream@1.4.5:
-    dependencies:
-      once: 1.4.0
 
   es-define-property@1.0.1: {}
 
@@ -1513,93 +366,13 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.4
 
-  escape-html@1.0.3: {}
-
-  escape-string-regexp@4.0.0:
-    optional: true
-
-  etag@1.8.1: {}
+  escape-string-regexp@4.0.0: {}
 
   event-target-shim@5.0.1: {}
 
-  eventsource-parser@3.1.0: {}
-
-  eventsource@3.0.7:
-    dependencies:
-      eventsource-parser: 3.1.0
-
-  express-rate-limit@8.5.2(express@5.2.1):
-    dependencies:
-      express: 5.2.1
-      ip-address: 10.2.0
-
-  express@5.2.1:
-    dependencies:
-      accepts: 2.0.0
-      body-parser: 2.2.2
-      content-disposition: 1.1.0
-      content-type: 1.0.5
-      cookie: 0.7.2
-      cookie-signature: 1.2.2
-      debug: 4.4.3
-      depd: 2.0.0
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      finalhandler: 2.1.1
-      fresh: 2.0.0
-      http-errors: 2.0.1
-      merge-descriptors: 2.0.0
-      mime-types: 3.0.2
-      on-finished: 2.4.1
-      once: 1.4.0
-      parseurl: 1.3.3
-      proxy-addr: 2.0.7
-      qs: 6.15.2
-      range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.1
-      serve-static: 2.2.1
-      statuses: 2.0.2
-      type-is: 2.1.0
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  extend@3.0.2: {}
-
-  fast-copy@4.0.3: {}
-
-  fast-deep-equal@3.1.3: {}
-
-  fast-safe-stringify@2.1.1: {}
-
-  fast-uri@3.1.2: {}
-
-  fetch-blob@3.2.0:
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 3.3.3
-
-  fetch-cookie@3.2.0:
-    dependencies:
-      set-cookie-parser: 2.7.2
-      tough-cookie: 6.0.1
-
-  finalhandler@2.1.1:
-    dependencies:
-      debug: 4.4.3
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
   form-data-encoder@1.7.2: {}
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -1612,31 +385,7 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 4.0.0-beta.3
 
-  formdata-polyfill@4.0.10:
-    dependencies:
-      fetch-blob: 3.2.0
-
-  forwarded@0.2.0: {}
-
-  fresh@2.0.0: {}
-
   function-bind@1.1.2: {}
-
-  gaxios@7.1.5:
-    dependencies:
-      extend: 3.0.2
-      https-proxy-agent: 7.0.6
-      node-fetch: 3.3.2
-    transitivePeerDependencies:
-      - supports-color
-
-  gcp-metadata@8.1.2:
-    dependencies:
-      gaxios: 7.1.5
-      google-logging-utils: 1.1.3
-      json-bigint: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -1656,19 +405,6 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.2
 
-  google-auth-library@10.7.0:
-    dependencies:
-      base64-js: 1.5.1
-      ecdsa-sig-formatter: 1.0.11
-      gaxios: 7.1.5
-      gcp-metadata: 8.1.2
-      google-logging-utils: 1.1.3
-      jws: 4.0.1
-    transitivePeerDependencies:
-      - supports-color
-
-  google-logging-utils@1.1.3: {}
-
   gopd@1.2.0: {}
 
   has-symbols@1.1.0: {}
@@ -1681,75 +417,15 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  help-me@5.0.0: {}
-
-  hono@4.12.25: {}
-
-  http-errors@2.0.1:
-    dependencies:
-      depd: 2.0.0
-      inherits: 2.0.4
-      setprototypeof: 1.2.0
-      statuses: 2.0.2
-      toidentifier: 1.0.1
-
-  https-proxy-agent@7.0.6:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
   humanize-ms@1.2.1:
     dependencies:
       ms: 2.1.3
 
-  iconv-lite@0.7.2:
-    dependencies:
-      safer-buffer: 2.1.2
-
-  inherits@2.0.4: {}
-
-  ip-address@10.2.0: {}
-
-  ipaddr.js@1.9.1: {}
-
-  is-docker@2.2.1:
-    optional: true
-
-  is-promise@4.0.0: {}
+  is-docker@2.2.1: {}
 
   is-wsl@2.2.0:
     dependencies:
       is-docker: 2.2.1
-    optional: true
-
-  isexe@2.0.0: {}
-
-  jose@6.2.3: {}
-
-  joycon@3.1.1: {}
-
-  json-bigint@1.0.0:
-    dependencies:
-      bignumber.js: 9.3.1
-
-  json-schema-traverse@1.0.0: {}
-
-  json-schema-typed@8.0.2: {}
-
-  json-schema@0.4.0: {}
-
-  jwa@2.0.1:
-    dependencies:
-      buffer-equal-constant-time: 1.0.1
-      ecdsa-sig-formatter: 1.0.11
-      safe-buffer: 5.2.1
-
-  jws@4.0.1:
-    dependencies:
-      jwa: 2.0.1
-      safe-buffer: 5.2.1
 
   lighthouse-logger@2.0.2:
     dependencies:
@@ -1757,36 +433,18 @@ snapshots:
       marky: 1.3.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
-  long@5.3.2: {}
-
-  marky@1.3.0:
-    optional: true
+  marky@1.3.0: {}
 
   math-intrinsics@1.1.0: {}
 
-  media-typer@1.1.0: {}
-
-  merge-descriptors@2.0.0: {}
-
   mime-db@1.52.0: {}
-
-  mime-db@1.54.0: {}
 
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
 
-  mime-types@3.0.2:
-    dependencies:
-      mime-db: 1.54.0
-
-  minimist@1.2.8: {}
-
   ms@2.1.3: {}
-
-  negotiator@1.0.0: {}
 
   node-domexception@1.0.0: {}
 
@@ -1794,289 +452,13 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
-  node-fetch@3.3.2:
-    dependencies:
-      data-uri-to-buffer: 4.0.1
-      fetch-blob: 3.2.0
-      formdata-polyfill: 4.0.10
-
-  node-gyp-build@4.8.4:
-    optional: true
-
-  object-assign@4.1.1: {}
-
-  object-inspect@1.13.4: {}
-
-  ollama-ai-provider-v2@1.5.5(zod@4.2.0):
-    dependencies:
-      '@ai-sdk/provider': 2.0.3
-      '@ai-sdk/provider-utils': 3.0.25(zod@4.2.0)
-      zod: 4.2.0
-    optional: true
-
-  on-exit-leak-free@2.1.2: {}
-
-  on-finished@2.4.1:
-    dependencies:
-      ee-first: 1.1.1
-
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
-
-  openai@4.104.0(ws@8.21.0(bufferutil@4.1.0))(zod@4.2.0):
-    dependencies:
-      '@types/node': 18.19.130
-      '@types/node-fetch': 2.6.13
-      abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.7.0
-    optionalDependencies:
-      ws: 8.21.0(bufferutil@4.1.0)
-      zod: 4.2.0
-    transitivePeerDependencies:
-      - encoding
-
-  p-retry@4.6.2:
-    dependencies:
-      '@types/retry': 0.12.0
-      retry: 0.13.1
-
-  parseurl@1.3.3: {}
-
-  patchright-core@1.57.0:
-    optional: true
-
-  path-key@3.1.1: {}
-
-  path-to-regexp@8.4.2: {}
-
-  pino-abstract-transport@2.0.0:
-    dependencies:
-      split2: 4.2.0
-
-  pino-abstract-transport@3.0.0:
-    dependencies:
-      split2: 4.2.0
-
-  pino-pretty@13.1.3:
-    dependencies:
-      colorette: 2.0.20
-      dateformat: 4.6.3
-      fast-copy: 4.0.3
-      fast-safe-stringify: 2.1.1
-      help-me: 5.0.0
-      joycon: 3.1.1
-      minimist: 1.2.8
-      on-exit-leak-free: 2.1.2
-      pino-abstract-transport: 3.0.0
-      pump: 3.0.4
-      secure-json-parse: 4.1.0
-      sonic-boom: 4.2.1
-      strip-json-comments: 5.0.3
-
-  pino-std-serializers@7.1.0: {}
-
-  pino@9.14.0:
-    dependencies:
-      '@pinojs/redact': 0.4.0
-      atomic-sleep: 1.0.0
-      on-exit-leak-free: 2.1.2
-      pino-abstract-transport: 2.0.0
-      pino-std-serializers: 7.1.0
-      process-warning: 5.0.0
-      quick-format-unescaped: 4.0.4
-      real-require: 0.2.0
-      safe-stable-stringify: 2.5.0
-      sonic-boom: 4.2.1
-      thread-stream: 3.2.0
-
-  pkce-challenge@5.0.1: {}
-
-  playwright-core@1.57.0:
-    optional: true
-
-  process-warning@5.0.0: {}
-
-  protobufjs@7.6.2:
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.5
-      '@protobufjs/eventemitter': 1.1.1
-      '@protobufjs/fetch': 1.1.1
-      '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.2
-      '@protobufjs/path': 1.1.2
-      '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.1
-      '@types/node': 22.19.3
-      long: 5.3.2
-
-  proxy-addr@2.0.7:
-    dependencies:
-      forwarded: 0.2.0
-      ipaddr.js: 1.9.1
-
-  pump@3.0.4:
-    dependencies:
-      end-of-stream: 1.4.5
-      once: 1.4.0
-
-  qs@6.15.2:
-    dependencies:
-      side-channel: 1.1.1
-
-  quick-format-unescaped@4.0.4: {}
-
-  range-parser@1.2.1: {}
-
-  raw-body@3.0.2:
-    dependencies:
-      bytes: 3.1.2
-      http-errors: 2.0.1
-      iconv-lite: 0.7.2
-      unpipe: 1.0.0
-
-  real-require@0.2.0: {}
-
-  require-from-string@2.0.2: {}
-
-  retry@0.13.1: {}
-
-  router@2.2.0:
-    dependencies:
-      debug: 4.4.3
-      depd: 2.0.0
-      is-promise: 4.0.0
-      parseurl: 1.3.3
-      path-to-regexp: 8.4.2
-    transitivePeerDependencies:
-      - supports-color
-
-  safe-buffer@5.2.1: {}
-
-  safe-stable-stringify@2.5.0: {}
-
-  safer-buffer@2.1.2: {}
-
-  secure-json-parse@4.1.0: {}
-
-  send@1.2.1:
-    dependencies:
-      debug: 4.4.3
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 2.0.0
-      http-errors: 2.0.1
-      mime-types: 3.0.2
-      ms: 2.1.3
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
-  serve-static@2.2.1:
-    dependencies:
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      parseurl: 1.3.3
-      send: 1.2.1
-    transitivePeerDependencies:
-      - supports-color
-
-  set-cookie-parser@2.7.2: {}
-
-  setprototypeof@1.2.0: {}
-
-  shebang-command@2.0.0:
-    dependencies:
-      shebang-regex: 3.0.0
-
-  shebang-regex@3.0.0: {}
-
-  side-channel-list@1.0.1:
-    dependencies:
-      es-errors: 1.3.0
-      object-inspect: 1.13.4
-
-  side-channel-map@1.0.1:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      object-inspect: 1.13.4
-
-  side-channel-weakmap@1.0.2:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      object-inspect: 1.13.4
-      side-channel-map: 1.0.1
-
-  side-channel@1.1.1:
-    dependencies:
-      es-errors: 1.3.0
-      object-inspect: 1.13.4
-      side-channel-list: 1.0.1
-      side-channel-map: 1.0.1
-      side-channel-weakmap: 1.0.2
-
-  sonic-boom@4.2.1:
-    dependencies:
-      atomic-sleep: 1.0.0
-
-  split2@4.2.0: {}
-
-  statuses@2.0.2: {}
-
-  strip-json-comments@5.0.3: {}
-
-  thread-stream@3.2.0:
-    dependencies:
-      real-require: 0.2.0
-
-  tldts-core@7.4.2: {}
-
-  tldts@7.4.2:
-    dependencies:
-      tldts-core: 7.4.2
-
-  toidentifier@1.0.1: {}
-
-  tough-cookie@6.0.1:
-    dependencies:
-      tldts: 7.4.2
-
   tr46@0.0.3: {}
-
-  tslib@2.8.1:
-    optional: true
-
-  type-is@2.1.0:
-    dependencies:
-      content-type: 2.0.0
-      media-typer: 1.1.0
-      mime-types: 3.0.2
 
   typescript@5.9.3: {}
 
   undici-types@5.26.5: {}
 
   undici-types@6.21.0: {}
-
-  unpipe@1.0.0: {}
-
-  uuid@11.1.1: {}
-
-  vary@1.1.2: {}
-
-  web-streams-polyfill@3.3.3: {}
 
   web-streams-polyfill@4.0.0-beta.3: {}
 
@@ -2087,18 +469,6 @@ snapshots:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
 
-  which@2.0.2:
-    dependencies:
-      isexe: 2.0.0
+  ws@8.21.3: {}
 
-  wrappy@1.0.2: {}
-
-  ws@8.21.0(bufferutil@4.1.0):
-    optionalDependencies:
-      bufferutil: 4.1.0
-
-  zod-to-json-schema@3.25.2(zod@4.2.0):
-    dependencies:
-      zod: 4.2.0
-
-  zod@4.2.0: {}
+  zod@4.4.3: {}

--- a/pkg/templates/typescript/stagehand/stagehand-extension.ts
+++ b/pkg/templates/typescript/stagehand/stagehand-extension.ts
@@ -1,0 +1,24 @@
+import { Kernel } from "@onkernel/sdk";
+import { createReadStream } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Stagehand v4 runs as a Chrome extension alongside the browser. When
+// `localBrowser.connect` is called without an `extensionId`, Stagehand loads the
+// extension into the running browser over CDP via `Extensions.loadUnpacked`,
+// reading it from an absolute path on the *browser's* filesystem. Both the
+// unpacked extension and its archive ship inside the installed
+// @browserbasehq/stagehand package.
+const stagehandDist = dirname(fileURLToPath(import.meta.resolve("@browserbasehq/stagehand")));
+const STAGEHAND_EXTENSION_ZIP = join(stagehandDist, "assets/stagehand-extension.zip");
+const STAGEHAND_EXTENSION_DIR = join(stagehandDist, "extension");
+
+// Mirror the Stagehand extension onto the running browser's filesystem at the
+// exact path Stagehand loads it from, so a subsequent
+// `localBrowser.connect({ cdpUrl })` (no `extensionId`) finds it.
+export async function loadStagehandExtension(kernel: Kernel, sessionId: string): Promise<void> {
+  await kernel.browsers.fs.uploadZip(sessionId, {
+    dest_path: STAGEHAND_EXTENSION_DIR,
+    zip_file: createReadStream(STAGEHAND_EXTENSION_ZIP),
+  });
+}


### PR DESCRIPTION
Migrates `pkg/templates/typescript/stagehand` from Stagehand v3 to v4.

## Why

Stagehand v4 runs as a Chrome extension next to the browser instead of driving it purely over CDP. The v3 init path (`new Stagehand({ env: "LOCAL", localBrowserLaunchOptions: { cdpUrl } })` + `init()`) no longer exists.

`localBrowser.connect({ cdpUrl })` with no `extensionId` makes Stagehand load the extension into the running browser over CDP via `Extensions.loadUnpacked`, reading it from an absolute path on the browser's filesystem. The template creates a browser, uploads the extension onto the running browser at that path, then connects.

## What changed

- `package.json`: `@browserbasehq/stagehand` `^3.5.0` → `^4.0.0`. (`zod` `^4.2.0` already satisfies Stagehand v4's `zod@4.4.3`.)
- `index.ts`:
  - Create the Kernel browser.
  - `kernel.browsers.fs.uploadZip` the shipped extension archive (`dist/assets/stagehand-extension.zip`) onto the running browser at the dir Stagehand loads from (`dist/extension`).
  - Connect with `localBrowser.connect({ cdpUrl })` (no `extensionId`) and `Stagehand.create({ browser })`.
  - `await browser.context.activePage()` (page access is async in v4).
  - Unwrap `stagehand.extract(...)` via `{ data }` (v4 primitives return `{ data, metadata }`).
  - Close the connected browser explicitly in a `finally` (v4 only closes browsers it launched).
  - Read `MODEL` / `MODEL_API_KEY` from env, defaulting to `openai/gpt-4.1`.
- `.env.example`, `README.md`: document `MODEL` / `MODEL_API_KEY` and the connection flow.
- `pnpm-lock.yaml`: regenerated.

## Testing

- `tsc --noEmit` passes with the template's resolved deps (stagehand 4.0.0, @onkernel/sdk 0.23.0, zod 4.4.3).
- Deployed the template with `kernel deploy` and ran `kernel invoke ts-stagehand teamsize-task --payload '{"company":"kernel"}'`; it returned `{"teamSize":"6"}`. Deploy was run with `MODEL=google/gemini-2.5-flash` since that was the model key available in the test environment; the default OpenAI path is unchanged in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sample template and dependency bump only; no production auth or core platform changes.
> 
> **Overview**
> Upgrades the **TypeScript Stagehand** sample from v3 to **Stagehand v4**, which requires a Chrome extension on the remote browser instead of the old `new Stagehand({ env: "LOCAL" })` + `init()` CDP-only flow.
> 
> The template now **uploads** the extension from `@browserbasehq/stagehand` onto the Kernel browser via `kernel.browsers.fs.uploadZip`, connects with **`localBrowser.connect({ cdpUrl })`** and **`Stagehand.create({ browser })`**, uses **`await browser.context.activePage()`**, unwraps **`extract`** as **`{ data }`**, and tears down Stagehand, the CDP connection, and the Kernel session in nested **`finally`** blocks. Configuration switches from **`OPENAI_API_KEY`** to provider-prefixed **`MODEL`** and **`MODEL_API_KEY`**. Docs and **`.env.example`** describe the v4 Kernel connection flow; **`pnpm-lock.yaml`** reflects **`@browserbasehq/stagehand` ^4.0.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bd9f747a80888c1a24e7f47d77c66c262b0ed22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->