### PR TITLE
Show profile save behavior in browser tables

### DIFF
--- a/cmd/browsers.go
+++ b/cmd/browsers.go
@@ -409,7 +409,7 @@ func (b BrowsersCmd) List(ctx context.Context, in BrowsersListInput) error {
 	}
 
 	// Prepare table data
-	headers := []string{"Browser ID", "Name", "Created At", "Profile", "Pool", "CDP WS URL", "Live View URL"}
+	headers := []string{"Browser ID", "Name", "Created At", "Profile", "Save Changes", "Pool", "CDP WS URL", "Live View URL"}
 	showDeletedAt := in.IncludeDeleted || in.Status == "deleted" || in.Status == "all"
 	if showDeletedAt {
 		headers = append(headers, "Deleted At")
@@ -436,6 +436,7 @@ func (b BrowsersCmd) List(ctx context.Context, in BrowsersListInput) error {
 			util.OrDash(browser.Name),
 			util.FormatLocal(browser.CreatedAt),
 			profile,
+			util.OrDash(formatProfileSaveChanges(browser.ProfileSaveChanges, browser.JSON.ProfileSaveChanges.Valid())),
 			pool,
 			truncateURL(browser.CdpWsURL, 50),
 			truncateURL(browser.BrowserLiveViewURL, 50),
@@ -575,20 +576,41 @@ func (b BrowsersCmd) Create(ctx context.Context, in BrowsersCreateInput) error {
 		return util.PrintPrettyJSON(browser)
 	}
 
-	printBrowserSessionResult(browser.SessionID, browser.CdpWsURL, browser.BrowserLiveViewURL, browser.Profile, browser.StartURL, browser.Name, browser.Tags)
+	printBrowserSessionResult(
+		browser.SessionID,
+		browser.CdpWsURL,
+		browser.BrowserLiveViewURL,
+		browser.Profile,
+		formatProfileSaveChanges(browser.ProfileSaveChanges, browser.JSON.ProfileSaveChanges.Valid()),
+		browser.StartURL,
+		browser.Name,
+		browser.Tags,
+	)
 	if in.Telemetry != "" {
 		printTelemetrySummary(browser.Telemetry)
 	}
 	return nil
 }
 
-func printBrowserSessionResult(sessionID, cdpURL, liveViewURL string, profile kernel.Profile, startURL, name string, tags kernel.Tags) {
-	tableData := buildBrowserTableData(sessionID, cdpURL, liveViewURL, profile, startURL, name, tags)
+func printBrowserSessionResult(
+	sessionID, cdpURL, liveViewURL string,
+	profile kernel.Profile,
+	profileSaveChanges, startURL, name string,
+	tags kernel.Tags,
+) {
+	tableData := buildBrowserTableData(sessionID, cdpURL, liveViewURL, profile, profileSaveChanges, startURL, name, tags)
 	PrintTableNoPad(tableData, true)
 }
 
+func formatProfileSaveChanges(value, valid bool) string {
+	if !valid {
+		return ""
+	}
+	return strconv.FormatBool(value)
+}
+
 // buildBrowserTableData creates a base table with common browser session fields.
-func buildBrowserTableData(sessionID, cdpURL, liveViewURL string, profile kernel.Profile, startURL, name string, tags kernel.Tags) pterm.TableData {
+func buildBrowserTableData(sessionID, cdpURL, liveViewURL string, profile kernel.Profile, profileSaveChanges, startURL, name string, tags kernel.Tags) pterm.TableData {
 	tableData := pterm.TableData{
 		{"Property", "Value"},
 		{"Session ID", sessionID},
@@ -606,6 +628,9 @@ func buildBrowserTableData(sessionID, cdpURL, liveViewURL string, profile kernel
 			profVal = profile.ID
 		}
 		tableData = append(tableData, []string{"Profile", profVal})
+	}
+	if profileSaveChanges != "" {
+		tableData = append(tableData, []string{"Save Changes", profileSaveChanges})
 	}
 	if startURL != "" {
 		tableData = append(tableData, []string{"Start URL", startURL})
@@ -683,6 +708,7 @@ func (b BrowsersCmd) Get(ctx context.Context, in BrowsersGetInput) error {
 		browser.CdpWsURL,
 		browser.BrowserLiveViewURL,
 		browser.Profile,
+		formatProfileSaveChanges(browser.ProfileSaveChanges, browser.JSON.ProfileSaveChanges.Valid()),
 		browser.StartURL,
 		browser.Name,
 		browser.Tags,
@@ -2988,7 +3014,16 @@ func runBrowsersCreate(cmd *cobra.Command, args []string) error {
 		if output == "json" {
 			return util.PrintPrettyJSON(resp)
 		}
-		printBrowserSessionResult(resp.SessionID, resp.CdpWsURL, resp.BrowserLiveViewURL, resp.Profile, resp.StartURL, resp.Name, resp.Tags)
+		printBrowserSessionResult(
+			resp.SessionID,
+			resp.CdpWsURL,
+			resp.BrowserLiveViewURL,
+			resp.Profile,
+			formatProfileSaveChanges(resp.ProfileSaveChanges, resp.JSON.ProfileSaveChanges.Valid()),
+			resp.StartURL,
+			resp.Name,
+			resp.Tags,
+		)
 		return nil
 	}
 

--- a/cmd/browsers_test.go
+++ b/cmd/browsers_test.go
@@ -448,7 +448,11 @@ func TestBuildBrowserTableData_PrintsProfileSaveChangesWhenPresent(t *testing.T)
 	assert.Contains(t, tableData, []string{"Save Changes", "false"})
 
 	tableData = buildBrowserTableData("session", "ws://cdp", "", kernel.Profile{}, "", "", "", nil)
-	assert.NotContains(t, tableData, []string{"Save Changes", "false"})
+	for _, row := range tableData {
+		if len(row) > 0 {
+			assert.NotEqual(t, "Save Changes", row[0])
+		}
+	}
 }
 
 func TestBrowsersList_PrintsErrorOnFailure(t *testing.T) {

--- a/cmd/browsers_test.go
+++ b/cmd/browsers_test.go
@@ -415,6 +415,42 @@ func TestBrowsersList_PrintsTableWithRows(t *testing.T) {
 	assert.Contains(t, out, "sess-2")
 }
 
+func TestBrowsersList_PrintsProfileSaveChanges(t *testing.T) {
+	setupStdoutCapture(t)
+
+	var writer kernel.BrowserListResponse
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"session_id": "writer",
+		"profile_save_changes": true
+	}`), &writer))
+	var reader kernel.BrowserListResponse
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"session_id": "reader",
+		"profile_save_changes": false
+	}`), &reader))
+
+	fake := &FakeBrowsersService{
+		ListFunc: func(ctx context.Context, query kernel.BrowserListParams, opts ...option.RequestOption) (*pagination.OffsetPagination[kernel.BrowserListResponse], error) {
+			return &pagination.OffsetPagination[kernel.BrowserListResponse]{Items: []kernel.BrowserListResponse{writer, reader}}, nil
+		},
+	}
+	b := BrowsersCmd{browsers: fake}
+	require.NoError(t, b.List(context.Background(), BrowsersListInput{}))
+
+	out := outBuf.String()
+	assert.Contains(t, out, "Save Changes")
+	assert.Contains(t, out, "true")
+	assert.Contains(t, out, "false")
+}
+
+func TestBuildBrowserTableData_PrintsProfileSaveChangesWhenPresent(t *testing.T) {
+	tableData := buildBrowserTableData("session", "ws://cdp", "", kernel.Profile{}, "false", "", "", nil)
+	assert.Contains(t, tableData, []string{"Save Changes", "false"})
+
+	tableData = buildBrowserTableData("session", "ws://cdp", "", kernel.Profile{}, "", "", "", nil)
+	assert.NotContains(t, tableData, []string{"Save Changes", "false"})
+}
+
 func TestBrowsersList_PrintsErrorOnFailure(t *testing.T) {
 	setupStdoutCapture(t)
 


### PR DESCRIPTION
## What

- add a **Save Changes** column to `kernel browsers list`
- show **Save Changes** in human-readable create, get, and browser-pool acquire result tables
- render explicit `true` and `false` values while preserving omission when the API did not return the field
- add coverage for list and detail table rendering

## Why

[kernel/kernel#3177](https://github.com/kernel/kernel/pull/3177) added `profile_save_changes` to browser responses, and `kernel-go-sdk v0.87.0` generated the corresponding field. JSON output already included it automatically, but human-readable tables hid it, making it harder to identify sessions that can overwrite a profile.

The CLI's current `main` branch already depends on `kernel-go-sdk v0.87.0`, so no additional SDK dependency bump is needed in this PR.

## Behavior

Before, human-readable browser output showed the attached profile without indicating whether the session would save changes. After this PR, it displays **Save Changes** as `true` or `false`; list output uses `-` when the response omits the field.

## Verification

- `GOCACHE=/private/tmp/kernel-cli-profile-save-gocache make test`
- focused browser table tests
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI display-only changes with no request or persistence logic; low risk aside from table layout.
> 
> **Overview**
> Human-readable browser output now surfaces **`profile_save_changes`** from the API, which JSON output already exposed.
> 
> **`kernel browsers list`** gains a **Save Changes** column. Create, get, and pool-acquire result tables show a **Save Changes** property when the field is present. A shared **`formatProfileSaveChanges`** helper prints `true`/`false` only when the SDK marks the field valid; otherwise list rows use `-` and detail tables omit the row.
> 
> Tests cover list output and **`buildBrowserTableData`** omission vs display behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1230d6b22647ed3c174ebd284b79562e35a0242. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->