### PR TITLE
Add private host network flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ Commands with JSON output support:
   - `--telemetry=<list>` - Per-category config, e.g. `--telemetry=network=on,page=off`
   - `--chrome-policy <json>` - Custom Chrome enterprise policy as a JSON object. Kernel-managed policies (extensions, proxy, automation) are rejected server-side.
   - `--chrome-policy-file <path>` - Read the Chrome enterprise policy from a file (use `-` for stdin). Mutually exclusive with `--chrome-policy`.
+  - `--private-host <host>` - Route a private hostname, IP, or CIDR through the session network instead of Kernel-managed egress. Repeatable or comma-separated; replaces the default private IP ranges.
+  - `--disable-private-hosts` - Disable direct routing for the default private IP ranges so all traffic uses Kernel-managed egress. Mutually exclusive with `--private-host`.
   - `--output json`, `-o json` - Output raw JSON object
   - _Note: When a pool is specified, omit other session configuration flags—pool settings determine profile, proxy, viewport, etc._
 - `kernel browsers delete <id-or-name>` - Delete a browser by ID or name
@@ -269,14 +271,14 @@ Commands with JSON output support:
   - `--timeout <seconds>` - Idle timeout for browsers acquired from the pool
   - `--stealth`, `--headless`, `--kiosk` - Default pool configuration
   - `--refresh-on-profile-update` - Flush idle browsers when the pool's profile is updated (requires a profile)
-  - `--profile-id`, `--profile-name`, `--proxy-id`, `--start-url`, `--extension`, `--viewport` - Same semantics as `kernel browsers create`
+  - `--profile-id`, `--profile-name`, `--proxy-id`, `--start-url`, `--extension`, `--viewport`, `--private-host`, `--disable-private-hosts` - Same semantics as `kernel browsers create`
   - `--chrome-policy <json>` / `--chrome-policy-file <path>` - Custom Chrome enterprise policy applied to every browser in the pool, as a JSON object or from a file (`-` for stdin). Same semantics as `kernel browsers create`.
   - `--telemetry=all` / `--telemetry=off` / `--telemetry=<categories>` - Telemetry applied to browsers warmed into the pool. Same semantics as `kernel browsers create`.
   - `--output json`, `-o json` - Output raw JSON object
 - `kernel browser-pools get <id-or-name>` - Get pool details
   - `--output json`, `-o json` - Output raw JSON object
 - `kernel browser-pools update <id-or-name>` - Update pool configuration
-  - Same flags as create plus `--clear-profile`, `--clear-proxy`, `--clear-start-url`, `--clear-extensions`, and `--clear-chrome-policy` for removing durable configuration. `--fill-rate 0` pauses automatic filling. `--discard-all-idle` discards all idle browsers and refills the pool. `--telemetry` updates only apply to browsers warmed after the update.
+  - Same flags as create plus `--clear-profile`, `--clear-proxy`, `--clear-start-url`, `--clear-extensions`, `--clear-chrome-policy`, and `--clear-private-hosts` for removing durable configuration. `--clear-private-hosts` restores the default private IP ranges. `--fill-rate 0` pauses automatic filling. `--discard-all-idle` discards all idle browsers and refills the pool. `--telemetry` and private-host updates only apply to browsers warmed after the update.
   - `--output json`, `-o json` - Output raw JSON object
 - `kernel browser-pools delete <id-or-name>` - Delete a pool
   - `--force` - Force delete even if browsers are leased

--- a/README.md
+++ b/README.md
@@ -227,7 +227,6 @@ Commands with JSON output support:
   - `--chrome-policy <json>` - Custom Chrome enterprise policy as a JSON object. Kernel-managed policies (extensions, proxy, automation) are rejected server-side.
   - `--chrome-policy-file <path>` - Read the Chrome enterprise policy from a file (use `-` for stdin). Mutually exclusive with `--chrome-policy`.
   - `--private-host <host>` - Route a private hostname, IP, or CIDR through the session network instead of Kernel-managed egress. Repeatable or comma-separated; replaces the default private IP ranges.
-  - `--disable-private-hosts` - Disable direct routing for the default private IP ranges so all traffic uses Kernel-managed egress. Mutually exclusive with `--private-host`.
   - `--output json`, `-o json` - Output raw JSON object
   - _Note: When a pool is specified, omit other session configuration flags—pool settings determine profile, proxy, viewport, etc._
 - `kernel browsers delete <id-or-name>` - Delete a browser by ID or name
@@ -271,7 +270,7 @@ Commands with JSON output support:
   - `--timeout <seconds>` - Idle timeout for browsers acquired from the pool
   - `--stealth`, `--headless`, `--kiosk` - Default pool configuration
   - `--refresh-on-profile-update` - Flush idle browsers when the pool's profile is updated (requires a profile)
-  - `--profile-id`, `--profile-name`, `--proxy-id`, `--start-url`, `--extension`, `--viewport`, `--private-host`, `--disable-private-hosts` - Same semantics as `kernel browsers create`
+  - `--profile-id`, `--profile-name`, `--proxy-id`, `--start-url`, `--extension`, `--viewport`, `--private-host` - Same semantics as `kernel browsers create`
   - `--chrome-policy <json>` / `--chrome-policy-file <path>` - Custom Chrome enterprise policy applied to every browser in the pool, as a JSON object or from a file (`-` for stdin). Same semantics as `kernel browsers create`.
   - `--telemetry=all` / `--telemetry=off` / `--telemetry=<categories>` - Telemetry applied to browsers warmed into the pool. Same semantics as `kernel browsers create`.
   - `--output json`, `-o json` - Output raw JSON object

--- a/cmd/browser_pools.go
+++ b/cmd/browser_pools.go
@@ -135,6 +135,8 @@ type BrowserPoolsCreateInput struct {
 	Viewport               string
 	ChromePolicy           string
 	ChromePolicyFile       string
+	PrivateHosts           []string
+	DisablePrivateHosts    bool
 	Telemetry              string
 	Output                 string
 }
@@ -145,6 +147,9 @@ func (c BrowserPoolsCmd) Create(ctx context.Context, in BrowserPoolsCreateInput)
 	}
 	if err := validateStartURLFlag(in.StartURL); err != nil {
 		return err
+	}
+	if len(in.PrivateHosts) > 0 && in.DisablePrivateHosts {
+		return fmt.Errorf("cannot specify both --private-host and --disable-private-hosts")
 	}
 
 	params := kernel.BrowserPoolNewParams{
@@ -210,6 +215,9 @@ func (c BrowserPoolsCmd) Create(ctx context.Context, in BrowserPoolsCreateInput)
 	}
 	if len(chromePolicy) > 0 {
 		params.ChromePolicy = chromePolicy
+	}
+	if len(in.PrivateHosts) > 0 || in.DisablePrivateHosts {
+		setPrivateHosts(&params.Network, in.PrivateHosts, in.DisablePrivateHosts)
 	}
 
 	if in.Telemetry != "" {
@@ -310,6 +318,9 @@ type BrowserPoolsUpdateInput struct {
 	ChromePolicy           string
 	ChromePolicyFile       string
 	ClearChromePolicy      bool
+	PrivateHosts           []string
+	DisablePrivateHosts    bool
+	ClearPrivateHosts      bool
 	Telemetry              string
 	DiscardAllIdle         BoolFlag
 	Output                 string
@@ -333,6 +344,19 @@ func validateBrowserPoolUpdateInput(in BrowserPoolsUpdateInput) error {
 	}
 	if (in.ChromePolicy != "" || in.ChromePolicyFile != "") && in.ClearChromePolicy {
 		return fmt.Errorf("cannot specify --clear-chrome-policy with --chrome-policy or --chrome-policy-file")
+	}
+	privateHostModes := 0
+	if len(in.PrivateHosts) > 0 {
+		privateHostModes++
+	}
+	if in.DisablePrivateHosts {
+		privateHostModes++
+	}
+	if in.ClearPrivateHosts {
+		privateHostModes++
+	}
+	if privateHostModes > 1 {
+		return fmt.Errorf("cannot combine --private-host, --disable-private-hosts, and --clear-private-hosts")
 	}
 	return nil
 }
@@ -422,6 +446,9 @@ func (c BrowserPoolsCmd) Update(ctx context.Context, in BrowserPoolsUpdateInput)
 	if len(chromePolicy) > 0 {
 		params.ChromePolicy = chromePolicy
 	}
+	if len(in.PrivateHosts) > 0 || in.DisablePrivateHosts {
+		setPrivateHosts(&params.Network, in.PrivateHosts, in.DisablePrivateHosts)
+	}
 
 	extraFields := map[string]any{}
 	// The SDK's omitzero encoder drops empty collections, so explicit clears use
@@ -431,6 +458,9 @@ func (c BrowserPoolsCmd) Update(ctx context.Context, in BrowserPoolsUpdateInput)
 	}
 	if in.ClearChromePolicy || (chromePolicy != nil && len(chromePolicy) == 0) {
 		extraFields["chrome_policy"] = map[string]any{}
+	}
+	if in.ClearPrivateHosts {
+		extraFields["network"] = map[string]any{}
 	}
 	if len(extraFields) > 0 {
 		params.SetExtraFields(extraFields)
@@ -686,8 +716,11 @@ func init() {
 	browserPoolsCreateCmd.Flags().String("viewport", "", "Viewport size (e.g. 1280x800)")
 	browserPoolsCreateCmd.Flags().String("chrome-policy", "", "Custom Chrome enterprise policy as a JSON object")
 	browserPoolsCreateCmd.Flags().String("chrome-policy-file", "", "Read Chrome enterprise policy (JSON object) from a file (use '-' for stdin)")
+	browserPoolsCreateCmd.Flags().StringSlice("private-host", nil, "Private hostname, IP, or CIDR to route through the session network (repeatable or comma-separated; replaces defaults)")
+	browserPoolsCreateCmd.Flags().Bool("disable-private-hosts", false, "Disable direct routing for the default private IP ranges")
 	browserPoolsCreateCmd.Flags().String("telemetry", "", "Configure telemetry for browsers warmed into the pool (opt-in): --telemetry=all (default set), --telemetry=off (disable), or --telemetry=console,network (capture exactly those categories)")
 	browserPoolsCreateCmd.MarkFlagsMutuallyExclusive("chrome-policy", "chrome-policy-file")
+	browserPoolsCreateCmd.MarkFlagsMutuallyExclusive("private-host", "disable-private-hosts")
 
 	addJSONOutputFlag(browserPoolsGetCmd)
 
@@ -712,7 +745,11 @@ func init() {
 	browserPoolsUpdateCmd.Flags().String("chrome-policy", "", "Custom Chrome enterprise policy as a JSON object")
 	browserPoolsUpdateCmd.Flags().String("chrome-policy-file", "", "Read Chrome enterprise policy (JSON object) from a file (use '-' for stdin)")
 	browserPoolsUpdateCmd.Flags().Bool("clear-chrome-policy", false, "Remove the pool's custom Chrome enterprise policy")
+	browserPoolsUpdateCmd.Flags().StringSlice("private-host", nil, "Replace private hosts routed through the session network (repeatable or comma-separated)")
+	browserPoolsUpdateCmd.Flags().Bool("disable-private-hosts", false, "Disable direct routing for the default private IP ranges")
+	browserPoolsUpdateCmd.Flags().Bool("clear-private-hosts", false, "Remove the private-host override and restore the default private IP ranges")
 	browserPoolsUpdateCmd.MarkFlagsMutuallyExclusive("chrome-policy", "chrome-policy-file")
+	browserPoolsUpdateCmd.MarkFlagsMutuallyExclusive("private-host", "disable-private-hosts", "clear-private-hosts")
 	browserPoolsUpdateCmd.Flags().String("telemetry", "", "Update pool telemetry: --telemetry=all (reset to default set), --telemetry=off (disable), or --telemetry=console,network (merge those categories into the current selection). Applies only to browsers warmed after the update.")
 	browserPoolsUpdateCmd.Flags().Bool("discard-all-idle", false, "Discard all idle browsers")
 	addJSONOutputFlag(browserPoolsUpdateCmd)
@@ -773,6 +810,8 @@ func runBrowserPoolsCreate(cmd *cobra.Command, args []string) error {
 	viewport, _ := cmd.Flags().GetString("viewport")
 	chromePolicy, _ := cmd.Flags().GetString("chrome-policy")
 	chromePolicyFile, _ := cmd.Flags().GetString("chrome-policy-file")
+	privateHosts, _ := cmd.Flags().GetStringSlice("private-host")
+	disablePrivateHosts, _ := cmd.Flags().GetBool("disable-private-hosts")
 	telemetry, _ := cmd.Flags().GetString("telemetry")
 	output, _ := cmd.Flags().GetString("output")
 
@@ -793,6 +832,8 @@ func runBrowserPoolsCreate(cmd *cobra.Command, args []string) error {
 		Viewport:               viewport,
 		ChromePolicy:           chromePolicy,
 		ChromePolicyFile:       chromePolicyFile,
+		PrivateHosts:           privateHosts,
+		DisablePrivateHosts:    disablePrivateHosts,
 		Telemetry:              telemetry,
 		Output:                 output,
 	}
@@ -832,6 +873,9 @@ func runBrowserPoolsUpdate(cmd *cobra.Command, args []string) error {
 	chromePolicy, _ := cmd.Flags().GetString("chrome-policy")
 	chromePolicyFile, _ := cmd.Flags().GetString("chrome-policy-file")
 	clearChromePolicy, _ := cmd.Flags().GetBool("clear-chrome-policy")
+	privateHosts, _ := cmd.Flags().GetStringSlice("private-host")
+	disablePrivateHosts, _ := cmd.Flags().GetBool("disable-private-hosts")
+	clearPrivateHosts, _ := cmd.Flags().GetBool("clear-private-hosts")
 	telemetry, _ := cmd.Flags().GetString("telemetry")
 	discardIdle, _ := cmd.Flags().GetBool("discard-all-idle")
 	output, _ := cmd.Flags().GetString("output")
@@ -859,6 +903,9 @@ func runBrowserPoolsUpdate(cmd *cobra.Command, args []string) error {
 		ChromePolicy:           chromePolicy,
 		ChromePolicyFile:       chromePolicyFile,
 		ClearChromePolicy:      clearChromePolicy,
+		PrivateHosts:           privateHosts,
+		DisablePrivateHosts:    disablePrivateHosts,
+		ClearPrivateHosts:      clearPrivateHosts,
 		Telemetry:              telemetry,
 		DiscardAllIdle:         BoolFlag{Set: cmd.Flags().Changed("discard-all-idle"), Value: discardIdle},
 		Output:                 output,

--- a/cmd/browser_pools.go
+++ b/cmd/browser_pools.go
@@ -136,7 +136,6 @@ type BrowserPoolsCreateInput struct {
 	ChromePolicy           string
 	ChromePolicyFile       string
 	PrivateHosts           []string
-	DisablePrivateHosts    bool
 	Telemetry              string
 	Output                 string
 }
@@ -147,9 +146,6 @@ func (c BrowserPoolsCmd) Create(ctx context.Context, in BrowserPoolsCreateInput)
 	}
 	if err := validateStartURLFlag(in.StartURL); err != nil {
 		return err
-	}
-	if len(in.PrivateHosts) > 0 && in.DisablePrivateHosts {
-		return fmt.Errorf("cannot specify both --private-host and --disable-private-hosts")
 	}
 
 	params := kernel.BrowserPoolNewParams{
@@ -216,8 +212,8 @@ func (c BrowserPoolsCmd) Create(ctx context.Context, in BrowserPoolsCreateInput)
 	if len(chromePolicy) > 0 {
 		params.ChromePolicy = chromePolicy
 	}
-	if len(in.PrivateHosts) > 0 || in.DisablePrivateHosts {
-		setPrivateHosts(&params.Network, in.PrivateHosts, in.DisablePrivateHosts)
+	if len(in.PrivateHosts) > 0 {
+		params.Network.PrivateHosts = in.PrivateHosts
 	}
 
 	if in.Telemetry != "" {
@@ -319,7 +315,6 @@ type BrowserPoolsUpdateInput struct {
 	ChromePolicyFile       string
 	ClearChromePolicy      bool
 	PrivateHosts           []string
-	DisablePrivateHosts    bool
 	ClearPrivateHosts      bool
 	Telemetry              string
 	DiscardAllIdle         BoolFlag
@@ -345,18 +340,8 @@ func validateBrowserPoolUpdateInput(in BrowserPoolsUpdateInput) error {
 	if (in.ChromePolicy != "" || in.ChromePolicyFile != "") && in.ClearChromePolicy {
 		return fmt.Errorf("cannot specify --clear-chrome-policy with --chrome-policy or --chrome-policy-file")
 	}
-	privateHostModes := 0
-	if len(in.PrivateHosts) > 0 {
-		privateHostModes++
-	}
-	if in.DisablePrivateHosts {
-		privateHostModes++
-	}
-	if in.ClearPrivateHosts {
-		privateHostModes++
-	}
-	if privateHostModes > 1 {
-		return fmt.Errorf("cannot combine --private-host, --disable-private-hosts, and --clear-private-hosts")
+	if len(in.PrivateHosts) > 0 && in.ClearPrivateHosts {
+		return fmt.Errorf("cannot specify both --private-host and --clear-private-hosts")
 	}
 	return nil
 }
@@ -446,8 +431,8 @@ func (c BrowserPoolsCmd) Update(ctx context.Context, in BrowserPoolsUpdateInput)
 	if len(chromePolicy) > 0 {
 		params.ChromePolicy = chromePolicy
 	}
-	if len(in.PrivateHosts) > 0 || in.DisablePrivateHosts {
-		setPrivateHosts(&params.Network, in.PrivateHosts, in.DisablePrivateHosts)
+	if len(in.PrivateHosts) > 0 {
+		params.Network.PrivateHosts = in.PrivateHosts
 	}
 
 	extraFields := map[string]any{}
@@ -717,10 +702,8 @@ func init() {
 	browserPoolsCreateCmd.Flags().String("chrome-policy", "", "Custom Chrome enterprise policy as a JSON object")
 	browserPoolsCreateCmd.Flags().String("chrome-policy-file", "", "Read Chrome enterprise policy (JSON object) from a file (use '-' for stdin)")
 	browserPoolsCreateCmd.Flags().StringSlice("private-host", nil, "Private hostname, IP, or CIDR to route through the session network (repeatable or comma-separated; replaces defaults)")
-	browserPoolsCreateCmd.Flags().Bool("disable-private-hosts", false, "Disable direct routing for the default private IP ranges")
 	browserPoolsCreateCmd.Flags().String("telemetry", "", "Configure telemetry for browsers warmed into the pool (opt-in): --telemetry=all (default set), --telemetry=off (disable), or --telemetry=console,network (capture exactly those categories)")
 	browserPoolsCreateCmd.MarkFlagsMutuallyExclusive("chrome-policy", "chrome-policy-file")
-	browserPoolsCreateCmd.MarkFlagsMutuallyExclusive("private-host", "disable-private-hosts")
 
 	addJSONOutputFlag(browserPoolsGetCmd)
 
@@ -746,10 +729,9 @@ func init() {
 	browserPoolsUpdateCmd.Flags().String("chrome-policy-file", "", "Read Chrome enterprise policy (JSON object) from a file (use '-' for stdin)")
 	browserPoolsUpdateCmd.Flags().Bool("clear-chrome-policy", false, "Remove the pool's custom Chrome enterprise policy")
 	browserPoolsUpdateCmd.Flags().StringSlice("private-host", nil, "Replace private hosts routed through the session network (repeatable or comma-separated)")
-	browserPoolsUpdateCmd.Flags().Bool("disable-private-hosts", false, "Disable direct routing for the default private IP ranges")
 	browserPoolsUpdateCmd.Flags().Bool("clear-private-hosts", false, "Remove the private-host override and restore the default private IP ranges")
 	browserPoolsUpdateCmd.MarkFlagsMutuallyExclusive("chrome-policy", "chrome-policy-file")
-	browserPoolsUpdateCmd.MarkFlagsMutuallyExclusive("private-host", "disable-private-hosts", "clear-private-hosts")
+	browserPoolsUpdateCmd.MarkFlagsMutuallyExclusive("private-host", "clear-private-hosts")
 	browserPoolsUpdateCmd.Flags().String("telemetry", "", "Update pool telemetry: --telemetry=all (reset to default set), --telemetry=off (disable), or --telemetry=console,network (merge those categories into the current selection). Applies only to browsers warmed after the update.")
 	browserPoolsUpdateCmd.Flags().Bool("discard-all-idle", false, "Discard all idle browsers")
 	addJSONOutputFlag(browserPoolsUpdateCmd)
@@ -811,7 +793,6 @@ func runBrowserPoolsCreate(cmd *cobra.Command, args []string) error {
 	chromePolicy, _ := cmd.Flags().GetString("chrome-policy")
 	chromePolicyFile, _ := cmd.Flags().GetString("chrome-policy-file")
 	privateHosts, _ := cmd.Flags().GetStringSlice("private-host")
-	disablePrivateHosts, _ := cmd.Flags().GetBool("disable-private-hosts")
 	telemetry, _ := cmd.Flags().GetString("telemetry")
 	output, _ := cmd.Flags().GetString("output")
 
@@ -833,7 +814,6 @@ func runBrowserPoolsCreate(cmd *cobra.Command, args []string) error {
 		ChromePolicy:           chromePolicy,
 		ChromePolicyFile:       chromePolicyFile,
 		PrivateHosts:           privateHosts,
-		DisablePrivateHosts:    disablePrivateHosts,
 		Telemetry:              telemetry,
 		Output:                 output,
 	}
@@ -874,7 +854,6 @@ func runBrowserPoolsUpdate(cmd *cobra.Command, args []string) error {
 	chromePolicyFile, _ := cmd.Flags().GetString("chrome-policy-file")
 	clearChromePolicy, _ := cmd.Flags().GetBool("clear-chrome-policy")
 	privateHosts, _ := cmd.Flags().GetStringSlice("private-host")
-	disablePrivateHosts, _ := cmd.Flags().GetBool("disable-private-hosts")
 	clearPrivateHosts, _ := cmd.Flags().GetBool("clear-private-hosts")
 	telemetry, _ := cmd.Flags().GetString("telemetry")
 	discardIdle, _ := cmd.Flags().GetBool("discard-all-idle")
@@ -904,7 +883,6 @@ func runBrowserPoolsUpdate(cmd *cobra.Command, args []string) error {
 		ChromePolicyFile:       chromePolicyFile,
 		ClearChromePolicy:      clearChromePolicy,
 		PrivateHosts:           privateHosts,
-		DisablePrivateHosts:    disablePrivateHosts,
 		ClearPrivateHosts:      clearPrivateHosts,
 		Telemetry:              telemetry,
 		DiscardAllIdle:         BoolFlag{Set: cmd.Flags().Changed("discard-all-idle"), Value: discardIdle},

--- a/cmd/browser_pools_test.go
+++ b/cmd/browser_pools_test.go
@@ -403,7 +403,7 @@ func TestBrowserPoolsUpdate_RejectsInvalidDurableInputs(t *testing.T) {
 		{
 			name:    "conflicting private host modes",
 			input:   BrowserPoolsUpdateInput{PrivateHosts: []string{"internal.example"}, ClearPrivateHosts: true},
-			wantErr: "cannot combine --private-host, --disable-private-hosts, and --clear-private-hosts",
+			wantErr: "cannot specify both --private-host and --clear-private-hosts",
 		},
 	}
 
@@ -442,25 +442,6 @@ func TestBrowserPoolsCreate_WithPrivateHosts(t *testing.T) {
 	assert.Equal(t, []string{"*.example.ts.net", "100.64.0.0/10"}, captured.Network.PrivateHosts)
 }
 
-func TestBrowserPoolsCreate_DisablePrivateHostsSendsExplicitEmptyList(t *testing.T) {
-	setupStdoutCapture(t)
-
-	var captured kernel.BrowserPoolNewParams
-	fake := &FakeBrowserPoolsService{
-		NewFunc: func(ctx context.Context, body kernel.BrowserPoolNewParams, opts ...option.RequestOption) (*kernel.BrowserPool, error) {
-			captured = body
-			return &kernel.BrowserPool{ID: "pool-network"}, nil
-		},
-	}
-
-	err := (BrowserPoolsCmd{client: fake}).Create(context.Background(), BrowserPoolsCreateInput{Size: 1, DisablePrivateHosts: true})
-	require.NoError(t, err)
-
-	raw, err := captured.MarshalJSON()
-	require.NoError(t, err)
-	assert.Contains(t, string(raw), `"network":{"private_hosts":[]}`)
-}
-
 func TestBrowserPoolsUpdate_PrivateHostModes(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -471,11 +452,6 @@ func TestBrowserPoolsUpdate_PrivateHostModes(t *testing.T) {
 			name:     "replace",
 			input:    BrowserPoolsUpdateInput{PrivateHosts: []string{"*.example.ts.net"}},
 			wantJSON: `"network":{"private_hosts":["*.example.ts.net"]}`,
-		},
-		{
-			name:     "disable",
-			input:    BrowserPoolsUpdateInput{DisablePrivateHosts: true},
-			wantJSON: `"network":{"private_hosts":[]}`,
 		},
 		{
 			name:     "restore defaults",

--- a/cmd/browser_pools_test.go
+++ b/cmd/browser_pools_test.go
@@ -400,6 +400,11 @@ func TestBrowserPoolsUpdate_RejectsInvalidDurableInputs(t *testing.T) {
 			input:   BrowserPoolsUpdateInput{FillRate: Int64Flag{Set: true, Value: -1}},
 			wantErr: "--fill-rate must be zero or greater",
 		},
+		{
+			name:    "conflicting private host modes",
+			input:   BrowserPoolsUpdateInput{PrivateHosts: []string{"internal.example"}, ClearPrivateHosts: true},
+			wantErr: "cannot combine --private-host, --disable-private-hosts, and --clear-private-hosts",
+		},
 	}
 
 	for _, tt := range tests {
@@ -414,6 +419,86 @@ func TestBrowserPoolsUpdate_RejectsInvalidDurableInputs(t *testing.T) {
 			tt.input.IDOrName = "pool-1"
 			err := (BrowserPoolsCmd{client: fake}).Update(context.Background(), tt.input)
 			require.EqualError(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestBrowserPoolsCreate_WithPrivateHosts(t *testing.T) {
+	setupStdoutCapture(t)
+
+	var captured kernel.BrowserPoolNewParams
+	fake := &FakeBrowserPoolsService{
+		NewFunc: func(ctx context.Context, body kernel.BrowserPoolNewParams, opts ...option.RequestOption) (*kernel.BrowserPool, error) {
+			captured = body
+			return &kernel.BrowserPool{ID: "pool-network"}, nil
+		},
+	}
+
+	err := (BrowserPoolsCmd{client: fake}).Create(context.Background(), BrowserPoolsCreateInput{
+		Size:         1,
+		PrivateHosts: []string{"*.example.ts.net", "100.64.0.0/10"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"*.example.ts.net", "100.64.0.0/10"}, captured.Network.PrivateHosts)
+}
+
+func TestBrowserPoolsCreate_DisablePrivateHostsSendsExplicitEmptyList(t *testing.T) {
+	setupStdoutCapture(t)
+
+	var captured kernel.BrowserPoolNewParams
+	fake := &FakeBrowserPoolsService{
+		NewFunc: func(ctx context.Context, body kernel.BrowserPoolNewParams, opts ...option.RequestOption) (*kernel.BrowserPool, error) {
+			captured = body
+			return &kernel.BrowserPool{ID: "pool-network"}, nil
+		},
+	}
+
+	err := (BrowserPoolsCmd{client: fake}).Create(context.Background(), BrowserPoolsCreateInput{Size: 1, DisablePrivateHosts: true})
+	require.NoError(t, err)
+
+	raw, err := captured.MarshalJSON()
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"network":{"private_hosts":[]}`)
+}
+
+func TestBrowserPoolsUpdate_PrivateHostModes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    BrowserPoolsUpdateInput
+		wantJSON string
+	}{
+		{
+			name:     "replace",
+			input:    BrowserPoolsUpdateInput{PrivateHosts: []string{"*.example.ts.net"}},
+			wantJSON: `"network":{"private_hosts":["*.example.ts.net"]}`,
+		},
+		{
+			name:     "disable",
+			input:    BrowserPoolsUpdateInput{DisablePrivateHosts: true},
+			wantJSON: `"network":{"private_hosts":[]}`,
+		},
+		{
+			name:     "restore defaults",
+			input:    BrowserPoolsUpdateInput{ClearPrivateHosts: true},
+			wantJSON: `"network":{}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupStdoutCapture(t)
+			var captured kernel.BrowserPoolUpdateParams
+			fake := &FakeBrowserPoolsService{
+				UpdateFunc: func(ctx context.Context, id string, body kernel.BrowserPoolUpdateParams, opts ...option.RequestOption) (*kernel.BrowserPool, error) {
+					captured = body
+					return &kernel.BrowserPool{ID: id}, nil
+				},
+			}
+			tt.input.IDOrName = "pool-network"
+			require.NoError(t, (BrowserPoolsCmd{client: fake}).Update(context.Background(), tt.input))
+			raw, err := captured.MarshalJSON()
+			require.NoError(t, err)
+			assert.Contains(t, string(raw), tt.wantJSON)
 		})
 	}
 }

--- a/cmd/browsers.go
+++ b/cmd/browsers.go
@@ -162,14 +162,6 @@ func parseViewport(viewport string) (width, height, refreshRate int64, err error
 	return w, h, refreshRate, nil
 }
 
-func setPrivateHosts(network *kernel.BrowserNetworkConfigParam, privateHosts []string, disabled bool) {
-	if disabled {
-		network.SetExtraFields(map[string]any{"private_hosts": []string{}})
-		return
-	}
-	network.PrivateHosts = privateHosts
-}
-
 // parseStringMapFlag parses repeated KEY=value flag values into a map. It returns a nil
 // map when no values were given, so callers can distinguish "flag absent" from "flag set
 // to an empty map".
@@ -301,7 +293,6 @@ type BrowsersCreateInput struct {
 	ChromePolicy       string
 	ChromePolicyFile   string
 	PrivateHosts       []string
-	PrivateHostsOff    bool
 	Name               string
 	Tags               map[string]string
 	Output             string
@@ -473,10 +464,6 @@ func (b BrowsersCmd) Create(ctx context.Context, in BrowsersCreateInput) error {
 	if err := validateStartURLFlag(in.StartURL); err != nil {
 		return err
 	}
-	if len(in.PrivateHosts) > 0 && in.PrivateHostsOff {
-		return fmt.Errorf("cannot specify both --private-host and --disable-private-hosts")
-	}
-
 	params := kernel.BrowserNewParams{}
 	if in.TimeoutSeconds > 0 {
 		params.TimeoutSeconds = kernel.Opt(int64(in.TimeoutSeconds))
@@ -568,8 +555,8 @@ func (b BrowsersCmd) Create(ctx context.Context, in BrowsersCreateInput) error {
 	if len(chromePolicy) > 0 {
 		params.ChromePolicy = chromePolicy
 	}
-	if len(in.PrivateHosts) > 0 || in.PrivateHostsOff {
-		setPrivateHosts(&params.Network, in.PrivateHosts, in.PrivateHostsOff)
+	if len(in.PrivateHosts) > 0 {
+		params.Network.PrivateHosts = in.PrivateHosts
 	}
 
 	if in.Name != "" {
@@ -2805,9 +2792,7 @@ func init() {
 	browsersCreateCmd.Flags().String("chrome-policy", "", "Custom Chrome enterprise policy as a JSON object")
 	browsersCreateCmd.Flags().String("chrome-policy-file", "", "Read Chrome enterprise policy (JSON object) from a file (use '-' for stdin)")
 	browsersCreateCmd.Flags().StringSlice("private-host", nil, "Private hostname, IP, or CIDR to route through the session network (repeatable or comma-separated; replaces defaults)")
-	browsersCreateCmd.Flags().Bool("disable-private-hosts", false, "Disable direct routing for the default private IP ranges")
 	browsersCreateCmd.MarkFlagsMutuallyExclusive("chrome-policy", "chrome-policy-file")
-	browsersCreateCmd.MarkFlagsMutuallyExclusive("private-host", "disable-private-hosts")
 
 	// curl
 	curlCmd := &cobra.Command{
@@ -2928,7 +2913,6 @@ func runBrowsersCreate(cmd *cobra.Command, args []string) error {
 	chromePolicy, _ := cmd.Flags().GetString("chrome-policy")
 	chromePolicyFile, _ := cmd.Flags().GetString("chrome-policy-file")
 	privateHosts, _ := cmd.Flags().GetStringSlice("private-host")
-	disablePrivateHosts, _ := cmd.Flags().GetBool("disable-private-hosts")
 	output, _ := cmd.Flags().GetString("output")
 	skipConfirm, _ := cmd.Flags().GetBool("yes")
 
@@ -3048,7 +3032,6 @@ func runBrowsersCreate(cmd *cobra.Command, args []string) error {
 		ChromePolicy:       chromePolicy,
 		ChromePolicyFile:   chromePolicyFile,
 		PrivateHosts:       privateHosts,
-		PrivateHostsOff:    disablePrivateHosts,
 		Name:               name,
 		Tags:               tags,
 		Output:             output,

--- a/cmd/browsers.go
+++ b/cmd/browsers.go
@@ -162,6 +162,14 @@ func parseViewport(viewport string) (width, height, refreshRate int64, err error
 	return w, h, refreshRate, nil
 }
 
+func setPrivateHosts(network *kernel.BrowserNetworkConfigParam, privateHosts []string, disabled bool) {
+	if disabled {
+		network.SetExtraFields(map[string]any{"private_hosts": []string{}})
+		return
+	}
+	network.PrivateHosts = privateHosts
+}
+
 // parseStringMapFlag parses repeated KEY=value flag values into a map. It returns a nil
 // map when no values were given, so callers can distinguish "flag absent" from "flag set
 // to an empty map".
@@ -292,6 +300,8 @@ type BrowsersCreateInput struct {
 	Telemetry          string
 	ChromePolicy       string
 	ChromePolicyFile   string
+	PrivateHosts       []string
+	PrivateHostsOff    bool
 	Name               string
 	Tags               map[string]string
 	Output             string
@@ -463,6 +473,9 @@ func (b BrowsersCmd) Create(ctx context.Context, in BrowsersCreateInput) error {
 	if err := validateStartURLFlag(in.StartURL); err != nil {
 		return err
 	}
+	if len(in.PrivateHosts) > 0 && in.PrivateHostsOff {
+		return fmt.Errorf("cannot specify both --private-host and --disable-private-hosts")
+	}
 
 	params := kernel.BrowserNewParams{}
 	if in.TimeoutSeconds > 0 {
@@ -554,6 +567,9 @@ func (b BrowsersCmd) Create(ctx context.Context, in BrowsersCreateInput) error {
 	}
 	if len(chromePolicy) > 0 {
 		params.ChromePolicy = chromePolicy
+	}
+	if len(in.PrivateHosts) > 0 || in.PrivateHostsOff {
+		setPrivateHosts(&params.Network, in.PrivateHosts, in.PrivateHostsOff)
 	}
 
 	if in.Name != "" {
@@ -2788,7 +2804,10 @@ func init() {
 	browsersCreateCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompts")
 	browsersCreateCmd.Flags().String("chrome-policy", "", "Custom Chrome enterprise policy as a JSON object")
 	browsersCreateCmd.Flags().String("chrome-policy-file", "", "Read Chrome enterprise policy (JSON object) from a file (use '-' for stdin)")
+	browsersCreateCmd.Flags().StringSlice("private-host", nil, "Private hostname, IP, or CIDR to route through the session network (repeatable or comma-separated; replaces defaults)")
+	browsersCreateCmd.Flags().Bool("disable-private-hosts", false, "Disable direct routing for the default private IP ranges")
 	browsersCreateCmd.MarkFlagsMutuallyExclusive("chrome-policy", "chrome-policy-file")
+	browsersCreateCmd.MarkFlagsMutuallyExclusive("private-host", "disable-private-hosts")
 
 	// curl
 	curlCmd := &cobra.Command{
@@ -2908,6 +2927,8 @@ func runBrowsersCreate(cmd *cobra.Command, args []string) error {
 	tags, _ := tagsFromFlag(cmd, "tag")
 	chromePolicy, _ := cmd.Flags().GetString("chrome-policy")
 	chromePolicyFile, _ := cmd.Flags().GetString("chrome-policy-file")
+	privateHosts, _ := cmd.Flags().GetStringSlice("private-host")
+	disablePrivateHosts, _ := cmd.Flags().GetBool("disable-private-hosts")
 	output, _ := cmd.Flags().GetString("output")
 	skipConfirm, _ := cmd.Flags().GetBool("yes")
 
@@ -3026,6 +3047,8 @@ func runBrowsersCreate(cmd *cobra.Command, args []string) error {
 		Telemetry:          telemetry,
 		ChromePolicy:       chromePolicy,
 		ChromePolicyFile:   chromePolicyFile,
+		PrivateHosts:       privateHosts,
+		PrivateHostsOff:    disablePrivateHosts,
 		Name:               name,
 		Tags:               tags,
 		Output:             output,

--- a/cmd/browsers_test.go
+++ b/cmd/browsers_test.go
@@ -486,6 +486,62 @@ func TestBrowsersCreate_WithNameAndTags(t *testing.T) {
 	assert.Contains(t, out, "env=staging, team=backend")
 }
 
+func TestBrowsersCreate_WithPrivateHosts(t *testing.T) {
+	setupStdoutCapture(t)
+
+	var captured kernel.BrowserNewParams
+	fake := &FakeBrowsersService{
+		NewFunc: func(ctx context.Context, body kernel.BrowserNewParams, opts ...option.RequestOption) (*kernel.BrowserNewResponse, error) {
+			captured = body
+			return &kernel.BrowserNewResponse{SessionID: "sess-network"}, nil
+		},
+	}
+
+	err := (BrowsersCmd{browsers: fake}).Create(context.Background(), BrowsersCreateInput{
+		PrivateHosts: []string{"*.example.ts.net", "100.64.0.0/10"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"*.example.ts.net", "100.64.0.0/10"}, captured.Network.PrivateHosts)
+
+	raw, err := captured.MarshalJSON()
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"private_hosts":["*.example.ts.net","100.64.0.0/10"]`)
+}
+
+func TestBrowsersCreate_PrivateHostsOffSendsExplicitEmptyList(t *testing.T) {
+	setupStdoutCapture(t)
+
+	var captured kernel.BrowserNewParams
+	fake := &FakeBrowsersService{
+		NewFunc: func(ctx context.Context, body kernel.BrowserNewParams, opts ...option.RequestOption) (*kernel.BrowserNewResponse, error) {
+			captured = body
+			return &kernel.BrowserNewResponse{SessionID: "sess-network"}, nil
+		},
+	}
+
+	err := (BrowsersCmd{browsers: fake}).Create(context.Background(), BrowsersCreateInput{PrivateHostsOff: true})
+	require.NoError(t, err)
+
+	raw, err := captured.MarshalJSON()
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"network":{"private_hosts":[]}`)
+}
+
+func TestBrowsersCreate_RejectsConflictingPrivateHostModes(t *testing.T) {
+	fake := &FakeBrowsersService{
+		NewFunc: func(context.Context, kernel.BrowserNewParams, ...option.RequestOption) (*kernel.BrowserNewResponse, error) {
+			t.Fatal("New should not be called for conflicting private-host flags")
+			return nil, nil
+		},
+	}
+
+	err := (BrowsersCmd{browsers: fake}).Create(context.Background(), BrowsersCreateInput{
+		PrivateHosts:    []string{"internal.example"},
+		PrivateHostsOff: true,
+	})
+	require.EqualError(t, err, "cannot specify both --private-host and --disable-private-hosts")
+}
+
 func TestBrowsersCreate_WithChromePolicy(t *testing.T) {
 	setupStdoutCapture(t)
 

--- a/cmd/browsers_test.go
+++ b/cmd/browsers_test.go
@@ -508,40 +508,6 @@ func TestBrowsersCreate_WithPrivateHosts(t *testing.T) {
 	assert.Contains(t, string(raw), `"private_hosts":["*.example.ts.net","100.64.0.0/10"]`)
 }
 
-func TestBrowsersCreate_PrivateHostsOffSendsExplicitEmptyList(t *testing.T) {
-	setupStdoutCapture(t)
-
-	var captured kernel.BrowserNewParams
-	fake := &FakeBrowsersService{
-		NewFunc: func(ctx context.Context, body kernel.BrowserNewParams, opts ...option.RequestOption) (*kernel.BrowserNewResponse, error) {
-			captured = body
-			return &kernel.BrowserNewResponse{SessionID: "sess-network"}, nil
-		},
-	}
-
-	err := (BrowsersCmd{browsers: fake}).Create(context.Background(), BrowsersCreateInput{PrivateHostsOff: true})
-	require.NoError(t, err)
-
-	raw, err := captured.MarshalJSON()
-	require.NoError(t, err)
-	assert.Contains(t, string(raw), `"network":{"private_hosts":[]}`)
-}
-
-func TestBrowsersCreate_RejectsConflictingPrivateHostModes(t *testing.T) {
-	fake := &FakeBrowsersService{
-		NewFunc: func(context.Context, kernel.BrowserNewParams, ...option.RequestOption) (*kernel.BrowserNewResponse, error) {
-			t.Fatal("New should not be called for conflicting private-host flags")
-			return nil, nil
-		},
-	}
-
-	err := (BrowsersCmd{browsers: fake}).Create(context.Background(), BrowsersCreateInput{
-		PrivateHosts:    []string{"internal.example"},
-		PrivateHostsOff: true,
-	})
-	require.EqualError(t, err, "cannot specify both --private-host and --disable-private-hosts")
-}
-
 func TestBrowsersCreate_WithChromePolicy(t *testing.T) {
 	setupStdoutCapture(t)
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.1
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/joho/godotenv v1.5.1
-	github.com/kernel/kernel-go-sdk v0.87.0
+	github.com/kernel/kernel-go-sdk v0.89.0
 	github.com/klauspost/compress v1.18.5
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pterm/pterm v0.12.80

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
-github.com/kernel/kernel-go-sdk v0.87.0 h1:Z5qRzvK9vSZbiOryVQ7XFT4WWh9W2Lcy+e5Brvk1TkY=
-github.com/kernel/kernel-go-sdk v0.87.0/go.mod h1:EeZzSuHZVeHKxKCPUzxou2bovNGhXaz0RXrSqKNf1AQ=
+github.com/kernel/kernel-go-sdk v0.89.0 h1:rhD0krIZ/pLdgxTluhb7WLozP4K9BPb0urzvmul3dII=
+github.com/kernel/kernel-go-sdk v0.89.0/go.mod h1:EeZzSuHZVeHKxKCPUzxou2bovNGhXaz0RXrSqKNf1AQ=
 github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
 github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=


### PR DESCRIPTION
## Summary

- bump the Go SDK to v0.89.0 for browser network configuration types
- add `--private-host` to browser and browser-pool creation
- add `--clear-private-hosts` to restore browser-pool defaults after an override
- preserve the API's omitted and configured network semantics without exposing the niche empty-list control in the CLI

## Testing

- `make test`
- production smoke: browser create/get/delete with `--private-host`
- production smoke: pool create/get, replace, clear, and delete lifecycle
- verified `--disable-private-hosts` is not exposed by browser or browser-pool commands