### PR TITLE
Add --region flag to browsers and browser-pools commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Commands with JSON output support:
 - `kernel browser-pools get <id-or-name>` - Get pool details
   - `--output json`, `-o json` - Output raw JSON object
 - `kernel browser-pools update <id-or-name>` - Update pool configuration
-  - Same flags as create plus `--clear-profile`, `--clear-proxy`, `--clear-start-url`, `--clear-extensions`, `--clear-chrome-policy`, and `--clear-private-hosts` for removing durable configuration. `--clear-private-hosts` restores the default private IP ranges. `--fill-rate 0` pauses automatic filling. `--discard-all-idle` discards all idle browsers and refills the pool. `--telemetry` and private-host updates only apply to browsers warmed after the update.
+  - Same flags as create (except `--region`, which is fixed at creation and cannot be updated) plus `--clear-profile`, `--clear-proxy`, `--clear-start-url`, `--clear-extensions`, `--clear-chrome-policy`, and `--clear-private-hosts` for removing durable configuration. `--clear-private-hosts` restores the default private IP ranges. `--fill-rate 0` pauses automatic filling. `--discard-all-idle` discards all idle browsers and refills the pool. `--telemetry` and private-host updates only apply to browsers warmed after the update.
   - `--output json`, `-o json` - Output raw JSON object
 - `kernel browser-pools delete <id-or-name>` - Delete a pool
   - `--force` - Force delete even if browsers are leased

--- a/README.md
+++ b/README.md
@@ -210,12 +210,14 @@ Commands with JSON output support:
 
 - `kernel browsers list` - List running browsers
   - `--query <q>` - Search by name, session ID, profile ID, proxy ID, or pool name
+  - `--region <region>` - Filter sessions by region (us-east or eu-west); omit to list sessions in all regions
   - `--tag <KEY=VALUE>` - Filter by tag, repeatable; a session must match every pair
   - `--output json`, `-o json` - Output raw JSON array
 - `kernel browsers create` - Create a new browser session
   - `-s, --stealth` - Launch browser in stealth mode to avoid detection
   - `-H, --headless` - Launch browser without GUI access
   - `--kiosk` - Launch browser in kiosk mode
+  - `--region <region>` - Region for the session (us-east or eu-west); fixed once created, defaults to us-east. Requires a Start-Up or Enterprise plan.
   - `--start-url <url>` - Initial page to open on launch
   - `--name <name>` - Optional unique name for the session (used to find it later by name; can be changed with `browsers update --name`)
   - `--tag <KEY=VALUE>` - Set a tag on the session, repeatable; up to 50 pairs
@@ -262,6 +264,7 @@ Commands with JSON output support:
 ### Browser Pools
 
 - `kernel browser-pools list` - List browser pools
+  - `--region <region>` - Filter pools by region (us-east or eu-west); omit to list pools in all regions
   - `--output json`, `-o json` - Output raw JSON array
 - `kernel browser-pools create` - Create a browser pool
   - `--name <name>` - Optional unique name for the pool
@@ -270,7 +273,7 @@ Commands with JSON output support:
   - `--timeout <seconds>` - Idle timeout for browsers acquired from the pool
   - `--stealth`, `--headless`, `--kiosk` - Default pool configuration
   - `--refresh-on-profile-update` - Flush idle browsers when the pool's profile is updated (requires a profile)
-  - `--profile-id`, `--profile-name`, `--proxy-id`, `--start-url`, `--extension`, `--viewport`, `--private-host` - Same semantics as `kernel browsers create`
+  - `--profile-id`, `--profile-name`, `--proxy-id`, `--region`, `--start-url`, `--extension`, `--viewport`, `--private-host` - Same semantics as `kernel browsers create`
   - `--chrome-policy <json>` / `--chrome-policy-file <path>` - Custom Chrome enterprise policy applied to every browser in the pool, as a JSON object or from a file (`-` for stdin). Same semantics as `kernel browsers create`.
   - `--telemetry=all` / `--telemetry=off` / `--telemetry=<categories>` - Telemetry applied to browsers warmed into the pool. Same semantics as `kernel browsers create`.
   - `--output json`, `-o json` - Output raw JSON object

--- a/cmd/browser_pools.go
+++ b/cmd/browser_pools.go
@@ -707,7 +707,7 @@ func init() {
 	browserPoolsCreateCmd.Flags().String("profile-id", "", "Profile ID")
 	browserPoolsCreateCmd.Flags().String("profile-name", "", "Profile name")
 	browserPoolsCreateCmd.Flags().String("proxy-id", "", "Proxy ID")
-	browserPoolsCreateCmd.Flags().String("region", "", "Region for the browser pool (us-east or eu-west); fixed once created, defaults to us-east")
+	browserPoolsCreateCmd.Flags().String("region", "", "Region for the browser pool (us-east or eu-west); fixed once created, defaults to us-east. Requires a Start-Up or Enterprise plan")
 	browserPoolsCreateCmd.Flags().String("start-url", "", "Initial page to open for new browsers")
 	browserPoolsCreateCmd.Flags().StringSlice("extension", []string{}, "Extension IDs or names")
 	browserPoolsCreateCmd.Flags().String("viewport", "", "Viewport size (e.g. 1280x800)")

--- a/cmd/browser_pools.go
+++ b/cmd/browser_pools.go
@@ -33,6 +33,7 @@ type BrowserPoolsCmd struct {
 type BrowserPoolsListInput struct {
 	Limit  int
 	Offset int
+	Region string
 	Output string
 }
 
@@ -47,6 +48,9 @@ func (c BrowserPoolsCmd) List(ctx context.Context, in BrowserPoolsListInput) err
 	}
 	if in.Offset > 0 {
 		params.Offset = kernel.Int(int64(in.Offset))
+	}
+	if in.Region != "" {
+		params.Region = kernel.BrowserPoolListParamsRegion(in.Region)
 	}
 
 	page, err := c.client.List(ctx, params)
@@ -73,7 +77,7 @@ func (c BrowserPoolsCmd) List(ctx context.Context, in BrowserPoolsListInput) err
 	}
 
 	tableData := pterm.TableData{
-		{"ID", "Name", "Available", "Acquired", "Created At", "Size"},
+		{"ID", "Name", "Available", "Acquired", "Created At", "Size", "Region"},
 	}
 
 	for _, p := range pools {
@@ -84,6 +88,7 @@ func (c BrowserPoolsCmd) List(ctx context.Context, in BrowserPoolsListInput) err
 			fmt.Sprintf("%d", p.AcquiredCount),
 			util.FormatLocal(p.CreatedAt),
 			fmt.Sprintf("%d", p.BrowserPoolConfig.Size),
+			string(p.Region),
 		})
 	}
 
@@ -130,6 +135,7 @@ type BrowserPoolsCreateInput struct {
 	ProfileID              string
 	ProfileName            string
 	ProxyID                string
+	Region                 string
 	StartURL               string
 	Extensions             []string
 	Viewport               string
@@ -189,6 +195,9 @@ func (c BrowserPoolsCmd) Create(ctx context.Context, in BrowserPoolsCreateInput)
 
 	if in.ProxyID != "" {
 		params.ProxyID = kernel.String(in.ProxyID)
+	}
+	if in.Region != "" {
+		params.Region = kernel.BrowserPoolNewParamsRegion(in.Region)
 	}
 	if in.StartURL != "" {
 		params.StartURL = kernel.String(in.StartURL)
@@ -270,6 +279,7 @@ func (c BrowserPoolsCmd) Get(ctx context.Context, in BrowserPoolsGetInput) error
 		{"ID", pool.ID},
 		{"Name", util.OrDash(pool.Name)},
 		{"Created At", util.FormatLocal(pool.CreatedAt)},
+		{"Region", string(pool.Region)},
 		{"Size", fmt.Sprintf("%d", cfg.Size)},
 		{"Available", fmt.Sprintf("%d", pool.AvailableCount)},
 		{"Acquired", fmt.Sprintf("%d", pool.AcquiredCount)},
@@ -682,6 +692,7 @@ func init() {
 	addJSONOutputFlag(browserPoolsListCmd)
 	browserPoolsListCmd.Flags().Int("limit", 0, "Maximum number of pools to return")
 	browserPoolsListCmd.Flags().Int("offset", 0, "Number of pools to skip (for pagination)")
+	browserPoolsListCmd.Flags().String("region", "", "Filter pools by region (us-east or eu-west); omit to list pools in all regions")
 
 	addJSONOutputFlag(browserPoolsCreateCmd)
 	browserPoolsCreateCmd.Flags().String("name", "", "Optional unique name for the pool")
@@ -696,6 +707,7 @@ func init() {
 	browserPoolsCreateCmd.Flags().String("profile-id", "", "Profile ID")
 	browserPoolsCreateCmd.Flags().String("profile-name", "", "Profile name")
 	browserPoolsCreateCmd.Flags().String("proxy-id", "", "Proxy ID")
+	browserPoolsCreateCmd.Flags().String("region", "", "Region for the browser pool (us-east or eu-west); fixed once created, defaults to us-east")
 	browserPoolsCreateCmd.Flags().String("start-url", "", "Initial page to open for new browsers")
 	browserPoolsCreateCmd.Flags().StringSlice("extension", []string{}, "Extension IDs or names")
 	browserPoolsCreateCmd.Flags().String("viewport", "", "Viewport size (e.g. 1280x800)")
@@ -763,8 +775,9 @@ func runBrowserPoolsList(cmd *cobra.Command, args []string) error {
 	out, _ := cmd.Flags().GetString("output")
 	limit, _ := cmd.Flags().GetInt("limit")
 	offset, _ := cmd.Flags().GetInt("offset")
+	region, _ := cmd.Flags().GetString("region")
 	c := BrowserPoolsCmd{client: &client.BrowserPools}
-	return c.List(cmd.Context(), BrowserPoolsListInput{Limit: limit, Offset: offset, Output: out})
+	return c.List(cmd.Context(), BrowserPoolsListInput{Limit: limit, Offset: offset, Region: region, Output: out})
 }
 
 func runBrowserPoolsCreate(cmd *cobra.Command, args []string) error {
@@ -787,6 +800,7 @@ func runBrowserPoolsCreate(cmd *cobra.Command, args []string) error {
 	profileID, _ := cmd.Flags().GetString("profile-id")
 	profileName, _ := cmd.Flags().GetString("profile-name")
 	proxyID, _ := cmd.Flags().GetString("proxy-id")
+	region, _ := cmd.Flags().GetString("region")
 	startURL, _ := cmd.Flags().GetString("start-url")
 	extensions, _ := cmd.Flags().GetStringSlice("extension")
 	viewport, _ := cmd.Flags().GetString("viewport")
@@ -808,6 +822,7 @@ func runBrowserPoolsCreate(cmd *cobra.Command, args []string) error {
 		ProfileID:              profileID,
 		ProfileName:            profileName,
 		ProxyID:                proxyID,
+		Region:                 region,
 		StartURL:               startURL,
 		Extensions:             extensions,
 		Viewport:               viewport,

--- a/cmd/browser_pools_test.go
+++ b/cmd/browser_pools_test.go
@@ -124,6 +124,31 @@ func TestBrowserPoolsList_ForwardsLimitOffset(t *testing.T) {
 	assert.Equal(t, int64(8), captured.Offset.Value)
 }
 
+func TestBrowserPoolsList_WithRegion(t *testing.T) {
+	setupStdoutCapture(t)
+
+	var captured kernel.BrowserPoolListParams
+	fake := &FakeBrowserPoolsService{
+		ListFunc: func(ctx context.Context, query kernel.BrowserPoolListParams, opts ...option.RequestOption) (*pagination.OffsetPagination[kernel.BrowserPool], error) {
+			captured = query
+			return &pagination.OffsetPagination[kernel.BrowserPool]{Items: []kernel.BrowserPool{
+				{ID: "pool-1", Region: kernel.BrowserPoolRegionEuWest},
+			}}, nil
+		},
+	}
+	c := BrowserPoolsCmd{client: fake}
+
+	err := c.List(context.Background(), BrowserPoolsListInput{Region: "eu-west"})
+	assert.NoError(t, err)
+	assert.Equal(t, kernel.BrowserPoolListParamsRegionEuWest, captured.Region)
+	assert.Contains(t, outBuf.String(), "eu-west")
+
+	// Omitting the flag leaves the param unset, so all regions are listed.
+	err = c.List(context.Background(), BrowserPoolsListInput{})
+	assert.NoError(t, err)
+	assert.Empty(t, captured.Region)
+}
+
 // TestBuildAcquireParams covers the shared name/tags/timeout/telemetry forwarding
 // used by both `browser-pools acquire` and the `browsers create --pool-id` lease path.
 func TestBuildAcquireParams(t *testing.T) {
@@ -147,6 +172,32 @@ func TestBuildAcquireParams(t *testing.T) {
 	// An invalid category surfaces an error rather than a partial param.
 	_, err = buildAcquireParams("", nil, 0, "bogus")
 	assert.Error(t, err)
+}
+
+func TestBrowserPoolsCreate_WithRegion(t *testing.T) {
+	setupStdoutCapture(t)
+
+	var captured kernel.BrowserPoolNewParams
+	fake := &FakeBrowserPoolsService{
+		NewFunc: func(ctx context.Context, body kernel.BrowserPoolNewParams, opts ...option.RequestOption) (*kernel.BrowserPool, error) {
+			captured = body
+			return &kernel.BrowserPool{ID: "pool-region"}, nil
+		},
+	}
+	c := BrowserPoolsCmd{client: fake}
+
+	err := c.Create(context.Background(), BrowserPoolsCreateInput{Size: 1, Region: "eu-west"})
+	assert.NoError(t, err)
+	assert.Equal(t, kernel.BrowserPoolNewParamsRegionEuWest, captured.Region)
+
+	// Omitting the flag sends nothing; the server defaults to us-east.
+	err = c.Create(context.Background(), BrowserPoolsCreateInput{Size: 1})
+	assert.NoError(t, err)
+	assert.Empty(t, captured.Region)
+
+	raw, err := captured.MarshalJSON()
+	assert.NoError(t, err)
+	assert.NotContains(t, string(raw), "region")
 }
 
 func TestBrowserPoolsCreate_WithRefreshOnProfileUpdate(t *testing.T) {

--- a/cmd/browser_pools_test.go
+++ b/cmd/browser_pools_test.go
@@ -17,6 +17,7 @@ import (
 // FakeBrowserPoolsService is a configurable fake implementing BrowserPoolsService.
 type FakeBrowserPoolsService struct {
 	AcquireFunc func(ctx context.Context, id string, body kernel.BrowserPoolAcquireParams, opts ...option.RequestOption) (*kernel.BrowserPoolAcquireResponse, error)
+	GetFunc     func(ctx context.Context, id string, opts ...option.RequestOption) (*kernel.BrowserPool, error)
 	ListFunc    func(ctx context.Context, query kernel.BrowserPoolListParams, opts ...option.RequestOption) (*pagination.OffsetPagination[kernel.BrowserPool], error)
 	NewFunc     func(ctx context.Context, body kernel.BrowserPoolNewParams, opts ...option.RequestOption) (*kernel.BrowserPool, error)
 	UpdateFunc  func(ctx context.Context, id string, body kernel.BrowserPoolUpdateParams, opts ...option.RequestOption) (*kernel.BrowserPool, error)
@@ -37,6 +38,9 @@ func (f *FakeBrowserPoolsService) New(ctx context.Context, body kernel.BrowserPo
 }
 
 func (f *FakeBrowserPoolsService) Get(ctx context.Context, id string, opts ...option.RequestOption) (*kernel.BrowserPool, error) {
+	if f.GetFunc != nil {
+		return f.GetFunc(ctx, id, opts...)
+	}
 	return &kernel.BrowserPool{}, nil
 }
 
@@ -139,13 +143,13 @@ func TestBrowserPoolsList_WithRegion(t *testing.T) {
 	c := BrowserPoolsCmd{client: fake}
 
 	err := c.List(context.Background(), BrowserPoolsListInput{Region: "eu-west"})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, kernel.BrowserPoolListParamsRegionEuWest, captured.Region)
 	assert.Contains(t, outBuf.String(), "eu-west")
 
 	// Omitting the flag leaves the param unset, so all regions are listed.
 	err = c.List(context.Background(), BrowserPoolsListInput{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Empty(t, captured.Region)
 }
 
@@ -187,17 +191,40 @@ func TestBrowserPoolsCreate_WithRegion(t *testing.T) {
 	c := BrowserPoolsCmd{client: fake}
 
 	err := c.Create(context.Background(), BrowserPoolsCreateInput{Size: 1, Region: "eu-west"})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, kernel.BrowserPoolNewParamsRegionEuWest, captured.Region)
+
+	raw, err := captured.MarshalJSON()
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"region":"eu-west"`)
 
 	// Omitting the flag sends nothing; the server defaults to us-east.
 	err = c.Create(context.Background(), BrowserPoolsCreateInput{Size: 1})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Empty(t, captured.Region)
 
-	raw, err := captured.MarshalJSON()
-	assert.NoError(t, err)
+	raw, err = captured.MarshalJSON()
+	require.NoError(t, err)
 	assert.NotContains(t, string(raw), "region")
+}
+
+func TestBrowserPoolsGet_ShowsRegion(t *testing.T) {
+	setupStdoutCapture(t)
+
+	fake := &FakeBrowserPoolsService{
+		GetFunc: func(ctx context.Context, id string, opts ...option.RequestOption) (*kernel.BrowserPool, error) {
+			return &kernel.BrowserPool{ID: id, Name: "eu-pool", Region: kernel.BrowserPoolRegionEuWest}, nil
+		},
+	}
+	c := BrowserPoolsCmd{client: fake}
+
+	err := c.Get(context.Background(), BrowserPoolsGetInput{IDOrName: "pool-1"})
+	require.NoError(t, err)
+
+	out := outBuf.String()
+	assert.Contains(t, out, "Region")
+	assert.Contains(t, out, "eu-pool")
+	assert.Contains(t, out, "eu-west")
 }
 
 func TestBrowserPoolsCreate_WithRefreshOnProfileUpdate(t *testing.T) {

--- a/cmd/browsers.go
+++ b/cmd/browsers.go
@@ -286,6 +286,7 @@ type BrowsersCreateInput struct {
 	ProfileName        string
 	ProfileSaveChanges BoolFlag
 	ProxyID            string
+	Region             string
 	StartURL           string
 	Extensions         []string
 	Viewport           string
@@ -353,6 +354,7 @@ type BrowsersListInput struct {
 	Limit          int
 	Offset         int
 	Query          string
+	Region         string
 	Tags           map[string]string
 }
 
@@ -386,6 +388,9 @@ func (b BrowsersCmd) List(ctx context.Context, in BrowsersListInput) error {
 	if in.Query != "" {
 		params.Query = kernel.Opt(in.Query)
 	}
+	if in.Region != "" {
+		params.Region = kernel.BrowserListParamsRegion(in.Region)
+	}
 	if len(in.Tags) > 0 {
 		params.Tags = in.Tags
 	}
@@ -410,7 +415,7 @@ func (b BrowsersCmd) List(ctx context.Context, in BrowsersListInput) error {
 	}
 
 	// Prepare table data
-	headers := []string{"Browser ID", "Name", "Created At", "Profile", "Pool", "CDP WS URL", "Live View URL"}
+	headers := []string{"Browser ID", "Name", "Created At", "Profile", "Pool", "Region", "CDP WS URL", "Live View URL"}
 	showDeletedAt := in.IncludeDeleted || in.Status == "deleted" || in.Status == "all"
 	if showDeletedAt {
 		headers = append(headers, "Deleted At")
@@ -438,6 +443,7 @@ func (b BrowsersCmd) List(ctx context.Context, in BrowsersListInput) error {
 			util.FormatLocal(browser.CreatedAt),
 			profile,
 			pool,
+			string(browser.Region),
 			truncateURL(browser.CdpWsURL, 50),
 			truncateURL(browser.BrowserLiveViewURL, 50),
 		}
@@ -502,6 +508,9 @@ func (b BrowsersCmd) Create(ctx context.Context, in BrowsersCreateInput) error {
 	// Add proxy if specified
 	if in.ProxyID != "" {
 		params.ProxyID = kernel.Opt(in.ProxyID)
+	}
+	if in.Region != "" {
+		params.Region = kernel.BrowserNewParamsRegion(in.Region)
 	}
 	if in.StartURL != "" {
 		params.StartURL = kernel.Opt(in.StartURL)
@@ -693,6 +702,7 @@ func (b BrowsersCmd) Get(ctx context.Context, in BrowsersGetInput) error {
 
 	// Append additional detailed fields
 	tableData = append(tableData, []string{"Created At", util.FormatLocal(browser.CreatedAt)})
+	tableData = append(tableData, []string{"Region", string(browser.Region)})
 	tableData = append(tableData, []string{"Timeout (seconds)", fmt.Sprintf("%d", browser.TimeoutSeconds)})
 	tableData = append(tableData, []string{"Headless", fmt.Sprintf("%t", browser.Headless)})
 	tableData = append(tableData, []string{"Stealth", fmt.Sprintf("%t", browser.Stealth)})
@@ -2490,6 +2500,7 @@ func init() {
 	browsersListCmd.Flags().Int("limit", 0, "Maximum number of results to return (default 20, max 100)")
 	browsersListCmd.Flags().Int("offset", 0, "Number of results to skip (for pagination)")
 	browsersListCmd.Flags().String("query", "", "Search browsers by name, session ID, profile ID, proxy ID, or pool name")
+	browsersListCmd.Flags().String("region", "", "Filter sessions by region (us-east or eu-west); omit to list sessions in all regions")
 	browsersListCmd.Flags().StringArray("tag", nil, "Filter by tag KEY=VALUE (repeatable; a session must match every pair)")
 
 	// get flags
@@ -2779,6 +2790,7 @@ func init() {
 	browsersCreateCmd.Flags().String("profile-name", "", "Profile name to load into the browser session (mutually exclusive with --profile-id)")
 	browsersCreateCmd.Flags().Bool("save-changes", false, "If set, save changes back to the profile when the session ends")
 	browsersCreateCmd.Flags().String("proxy-id", "", "Proxy ID to use for the browser session")
+	browsersCreateCmd.Flags().String("region", "", "Region for the browser session (us-east or eu-west); fixed once created, defaults to us-east")
 	browsersCreateCmd.Flags().String("start-url", "", "Initial page to open on launch")
 	browsersCreateCmd.Flags().StringSlice("extension", []string{}, "Extension IDs or names to load (repeatable; may be passed multiple times or comma-separated)")
 	browsersCreateCmd.Flags().String("viewport", "", "Browser viewport size (e.g., 1920x1080@25). Supported: 2560x1440@10, 1920x1080@25, 1920x1200@25, 1440x900@25, 1024x768@60, 1200x800@60, 1280x800@60")
@@ -2854,6 +2866,7 @@ func runBrowsersList(cmd *cobra.Command, args []string) error {
 	limit, _ := cmd.Flags().GetInt("limit")
 	offset, _ := cmd.Flags().GetInt("offset")
 	query, _ := cmd.Flags().GetString("query")
+	region, _ := cmd.Flags().GetString("region")
 	tags, _ := tagsFromFlag(cmd, "tag")
 	return b.List(cmd.Context(), BrowsersListInput{
 		Output:         out,
@@ -2862,6 +2875,7 @@ func runBrowsersList(cmd *cobra.Command, args []string) error {
 		Limit:          limit,
 		Offset:         offset,
 		Query:          query,
+		Region:         region,
 		Tags:           tags,
 	})
 }
@@ -2901,6 +2915,7 @@ func runBrowsersCreate(cmd *cobra.Command, args []string) error {
 	profileName, _ := cmd.Flags().GetString("profile-name")
 	saveChanges, _ := cmd.Flags().GetBool("save-changes")
 	proxyID, _ := cmd.Flags().GetString("proxy-id")
+	region, _ := cmd.Flags().GetString("region")
 	startURL, _ := cmd.Flags().GetString("start-url")
 	extensions, _ := cmd.Flags().GetStringSlice("extension")
 	viewport, _ := cmd.Flags().GetString("viewport")
@@ -3025,6 +3040,7 @@ func runBrowsersCreate(cmd *cobra.Command, args []string) error {
 		ProfileName:        profileName,
 		ProfileSaveChanges: BoolFlag{Set: cmd.Flags().Changed("save-changes"), Value: saveChanges},
 		ProxyID:            proxyID,
+		Region:             region,
 		StartURL:           startURL,
 		Extensions:         extensions,
 		Viewport:           viewport,

--- a/cmd/browsers.go
+++ b/cmd/browsers.go
@@ -2790,7 +2790,7 @@ func init() {
 	browsersCreateCmd.Flags().String("profile-name", "", "Profile name to load into the browser session (mutually exclusive with --profile-id)")
 	browsersCreateCmd.Flags().Bool("save-changes", false, "If set, save changes back to the profile when the session ends")
 	browsersCreateCmd.Flags().String("proxy-id", "", "Proxy ID to use for the browser session")
-	browsersCreateCmd.Flags().String("region", "", "Region for the browser session (us-east or eu-west); fixed once created, defaults to us-east")
+	browsersCreateCmd.Flags().String("region", "", "Region for the browser session (us-east or eu-west); fixed once created, defaults to us-east. Requires a Start-Up or Enterprise plan")
 	browsersCreateCmd.Flags().String("start-url", "", "Initial page to open on launch")
 	browsersCreateCmd.Flags().StringSlice("extension", []string{}, "Extension IDs or names to load (repeatable; may be passed multiple times or comma-separated)")
 	browsersCreateCmd.Flags().String("viewport", "", "Browser viewport size (e.g., 1920x1080@25). Supported: 2560x1440@10, 1920x1080@25, 1920x1200@25, 1440x900@25, 1024x768@60, 1200x800@60, 1280x800@60")

--- a/cmd/browsers_test.go
+++ b/cmd/browsers_test.go
@@ -550,12 +550,16 @@ func TestBrowsersCreate_WithRegion(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, kernel.BrowserNewParamsRegionEuWest, captured.Region)
 
+	raw, err := captured.MarshalJSON()
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"region":"eu-west"`)
+
 	// Omitting the flag sends nothing; the server defaults to us-east.
 	err = b.Create(context.Background(), BrowsersCreateInput{})
 	require.NoError(t, err)
 	assert.Empty(t, captured.Region)
 
-	raw, err := captured.MarshalJSON()
+	raw, err = captured.MarshalJSON()
 	require.NoError(t, err)
 	assert.NotContains(t, string(raw), "region")
 }

--- a/cmd/browsers_test.go
+++ b/cmd/browsers_test.go
@@ -393,12 +393,14 @@ func TestBrowsersList_PrintsTableWithRows(t *testing.T) {
 			CdpWsURL:           "ws://cdp-1",
 			BrowserLiveViewURL: "http://view-1",
 			CreatedAt:          created,
+			Region:             kernel.BrowserListResponseRegionEuWest,
 		},
 		{
 			SessionID:          "sess-2",
 			CdpWsURL:           "ws://cdp-2",
 			BrowserLiveViewURL: "",
 			CreatedAt:          created,
+			Region:             kernel.BrowserListResponseRegionUsEast,
 		},
 	}
 
@@ -413,6 +415,8 @@ func TestBrowsersList_PrintsTableWithRows(t *testing.T) {
 	out := outBuf.String()
 	assert.Contains(t, out, "sess-1")
 	assert.Contains(t, out, "sess-2")
+	assert.Contains(t, out, "eu-west")
+	assert.Contains(t, out, "us-east")
 }
 
 func TestBrowsersList_PrintsErrorOnFailure(t *testing.T) {
@@ -448,6 +452,28 @@ func TestBrowsersList_WithQuery_PassesParam(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, captured.Query.Valid())
 	assert.Equal(t, "sess-matched", captured.Query.Value)
+}
+
+func TestBrowsersList_WithRegion_PassesParam(t *testing.T) {
+	setupStdoutCapture(t)
+
+	var captured kernel.BrowserListParams
+	fake := &FakeBrowsersService{
+		ListFunc: func(ctx context.Context, query kernel.BrowserListParams, opts ...option.RequestOption) (*pagination.OffsetPagination[kernel.BrowserListResponse], error) {
+			captured = query
+			return &pagination.OffsetPagination[kernel.BrowserListResponse]{Items: []kernel.BrowserListResponse{}}, nil
+		},
+	}
+	b := BrowsersCmd{browsers: fake}
+
+	err := b.List(context.Background(), BrowsersListInput{Region: "eu-west"})
+	assert.NoError(t, err)
+	assert.Equal(t, kernel.BrowserListParamsRegionEuWest, captured.Region)
+
+	// Omitting the flag leaves the param unset, so all regions are listed.
+	err = b.List(context.Background(), BrowsersListInput{})
+	assert.NoError(t, err)
+	assert.Empty(t, captured.Region)
 }
 
 func TestBrowsersCreate_WithNameAndTags(t *testing.T) {
@@ -506,6 +532,32 @@ func TestBrowsersCreate_WithPrivateHosts(t *testing.T) {
 	raw, err := captured.MarshalJSON()
 	require.NoError(t, err)
 	assert.Contains(t, string(raw), `"private_hosts":["*.example.ts.net","100.64.0.0/10"]`)
+}
+
+func TestBrowsersCreate_WithRegion(t *testing.T) {
+	setupStdoutCapture(t)
+
+	var captured kernel.BrowserNewParams
+	fake := &FakeBrowsersService{
+		NewFunc: func(ctx context.Context, body kernel.BrowserNewParams, opts ...option.RequestOption) (*kernel.BrowserNewResponse, error) {
+			captured = body
+			return &kernel.BrowserNewResponse{SessionID: "sess-region"}, nil
+		},
+	}
+	b := BrowsersCmd{browsers: fake}
+
+	err := b.Create(context.Background(), BrowsersCreateInput{Region: "eu-west"})
+	require.NoError(t, err)
+	assert.Equal(t, kernel.BrowserNewParamsRegionEuWest, captured.Region)
+
+	// Omitting the flag sends nothing; the server defaults to us-east.
+	err = b.Create(context.Background(), BrowsersCreateInput{})
+	require.NoError(t, err)
+	assert.Empty(t, captured.Region)
+
+	raw, err := captured.MarshalJSON()
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "region")
 }
 
 func TestBrowsersCreate_WithChromePolicy(t *testing.T) {
@@ -995,6 +1047,7 @@ func TestBrowsersGet_PrintsDetails(t *testing.T) {
 				Viewport:           shared.BrowserViewport{Width: 1920, Height: 1080, RefreshRate: 25},
 				Profile:            kernel.Profile{ID: "prof-id", Name: "my-profile"},
 				ProxyID:            "proxy-123",
+				Region:             kernel.BrowserGetResponseRegionEuWest,
 			}, nil
 		},
 	}
@@ -1011,6 +1064,7 @@ func TestBrowsersGet_PrintsDetails(t *testing.T) {
 	assert.Contains(t, out, "1920x1080@25")
 	assert.Contains(t, out, "my-profile")
 	assert.Contains(t, out, "proxy-123")
+	assert.Contains(t, out, "eu-west")
 }
 
 func TestBrowsersGet_JSONOutput(t *testing.T) {


### PR DESCRIPTION
## Summary

The API now accepts a `region` field on browser/session and browser-pool create and list requests and returns it on every such resource, but the CLI had no way to pass or see it. This adds the CLI surface:

- `--region` string flag on `browsers create`, `browsers list`, `browser-pools create`, and `browser-pools list`. Per-command only — no persistent root flag, no env var.
- Pure pass-through into the SDK request params (`BrowserNewParams`, `BrowserListParams`, `BrowserPoolNewParams`, `BrowserPoolListParams`). When the flag is omitted the field is left unset, so the server default (`us-east`) applies and list returns all regions. No client-side validation beyond the SDK type — API 400/403 errors surface as-is.
- `Region` column/row in table output for `browsers list` + `browsers get` and `browser-pools list` + `browser-pools get`, rendered for all orgs since the API returns `region` as a required field.

Note: `go.mod` already pins `kernel-go-sdk` v0.89.0 on `main` (the first version with region support), so no SDK bump was needed.

## Testing

- `go build ./...` — passes
- `go vet ./...` — passes
- `go test ./...` — all packages pass
- New/extended tests, all passing:
  - `TestBrowsersCreate_WithRegion` / `TestBrowserPoolsCreate_WithRegion` — flag lands on create params and marshals to `"region":"eu-west"` on the wire; omission sends nothing (marshaled body contains no `region` key)
  - `TestBrowsersList_WithRegion_PassesParam` / `TestBrowserPoolsList_WithRegion` — flag lands on list params; omission leaves it unset
  - `TestBrowserPoolsGet_ShowsRegion` — new; covers the `browser-pools get` Region row
  - `TestBrowsersList_PrintsTableWithRows` / `TestBrowsersGet_PrintsDetails` — extended to assert the region renders in table output
- Verified `--region` appears in `--help` for the four commands and not on `get`/`update` (by-id lookups are region-free and region is immutable after create)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only pass-through to existing SDK/API region support; no auth or data-model changes, with tests covering the new flags and output.
> 
> **Overview**
> Adds **`--region`** (`us-east` / `eu-west`) so the CLI can set and filter regional browser sessions and pools, matching the API’s `region` field.
> 
> **Browsers:** `browsers create` passes `--region` through to the SDK (omitted → server default `us-east`; immutable after create). `browsers list` can filter by region (omitted → all regions). Table output for **list** and **get** includes a **Region** column. Using `--region` with `--pool-id` / `--pool-name` is treated like other pool-incompatible create flags (conflict warning).
> 
> **Browser pools:** Same pattern on `browser-pools create` and `list`, plus **Region** on list/get tables. Pool **update** has no `--region` (fixed at creation); README documents that.
> 
> Flags are per-command only (no global flag or env). Omitted values stay unset on the wire. Tests cover param forwarding, JSON omission, and table rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5085b982c77230c2a0b3b11cb52f65252863f17a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->